### PR TITLE
Prove the phase-1 shift sumcheck over sparse shift rows

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -9,13 +9,13 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
+use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims,
 		monster::{build_h, build_monster_segments},
-		phase_1::{PHASE_1_LOG_LEN, build_g, run_phase_1_sumcheck},
+		phase_1::{SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 	},
 };
@@ -31,8 +31,9 @@ use crate::witness::{FoldedWitness, FoldedWord};
 /// The public words are constants shared by every instance, so they are passed as raw words.
 ///
 /// The two phases call the single-instance prover's own subroutines.
-/// Phase 1 builds the hidden segment's g with [`build_g_from_folded_words`].
-/// It builds the public segment's g with the single-instance `build_g`, then sums the two.
+/// Phase 1 accumulates the hidden segment's g rows with [`build_g_from_folded_words`].
+/// It accumulates the public segment's with the single-instance `build_g`, then collects both
+/// segments' rows into the sparse `g` the phase-1 sumcheck reads.
 /// Phase 2 contracts the hidden witness along its bit axis with [`FoldedWitness::fold_bits`].
 /// It folds the public segment the same way, at the same challenge `r_j`.
 /// It then reuses `build_monster_segments` and `run_sumcheck` unchanged.
@@ -67,16 +68,18 @@ where
 	// SOUNDNESS: `prepare` draws in the order the verifier draws in; do not reorder it.
 	let prepared = claims.prepare(|| channel.sample());
 
-	// Phase 1: build g once per key segment, then add them. The public words are
-	// constants shared by every instance, so the single-instance builder folds them directly from
-	// their bits; the hidden words are already folded over instances. This scalar path drives the
-	// single-instance phase-1 sumcheck.
-	let mut g = build_g::<F, F, _>(alloc, public_words, &key_collection.public, &prepared);
-	let hidden_g =
-		build_g_from_folded_words(alloc, folded_witness.words(), &key_collection.hidden, &prepared);
-	for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
-		*slot += *add;
-	}
+	// Phase 1: accumulate the g rows once per key segment. The public words are constants shared
+	// by every instance, so the single-instance builder folds them directly from their bits; the
+	// hidden words are already folded over instances. This scalar path drives the single-instance
+	// phase-1 sumcheck.
+	let public = build_g::<F, F>(public_words, &key_collection.public, &prepared);
+	let hidden =
+		build_g_from_folded_words(folded_witness.words(), &key_collection.hidden, &prepared);
+	// `g` is the sum of its rows, so the two segments' rows concatenate rather than merge.
+	let g = SparseShiftRows::from_segments([
+		(&public, &key_collection.public.dense_shift_enc),
+		(&hidden, &key_collection.hidden.dense_shift_enc),
+	]);
 	let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
 	let phase_1_output =
 		run_phase_1_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
@@ -119,7 +122,7 @@ where
 	)
 }
 
-/// Constructs the phase-1 "g" multilinear parts, one per shift variant, from instance-folded words.
+/// Accumulates the phase-1 "g" rows of one key segment, from instance-folded words.
 ///
 /// This is the batched analogue of the single-instance [`build_g`].
 /// It consumes a key segment's words already folded over the instance axis.
@@ -131,7 +134,7 @@ where
 ///
 /// Use this for the hidden (committed) segment, whose words are folded over instances.
 /// Use [`build_g`] for the public segment, whose words are shared constants.
-/// Adding the two results gives the complete g multilinear.
+/// Collecting both results' rows gives the complete g multilinear.
 ///
 /// # Arguments
 ///
@@ -143,29 +146,24 @@ where
 ///
 /// # Returns
 ///
-/// One multilinear of [`PHASE_1_LOG_LEN`] variables, holding every shift variant's part.
-///
-/// The segment's dense shift encoding decodes a key's shift index into the variant and the shift
-/// amount. The variant indexes the high variables and the amount the middle ones, so a key names
-/// one run of bit slots:
+/// One row of `Word::BITS` scalars per shift the segment uses, in dense shift index order:
 ///
 /// ```text
-/// g[(variant * Word::BITS + amount) * Word::BITS + bit] += folded_bit * acc(key)
+/// rows[key.dense_shift_idx * Word::BITS + bit] += folded_bit * acc(key)
 /// ```
 ///
 /// where `acc(key)` is the key's lambda-weighted partial evaluation tensor.
-/// Every word carrying that key accumulates into the same slots.
+/// Every word carrying that key accumulates into the same row.
 ///
 /// This scalar implementation ignores the single-instance builder's packing and parallelism.
-pub fn build_g_from_folded_words<F: BinaryField, A: Allocator>(
-	alloc: &A,
+pub fn build_g_from_folded_words<F: BinaryField>(
 	folded_words: &[FoldedWord<F>],
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
-) -> FieldVec<F, A> {
-	// One zeroed multilinear covering every shift, drawn from the allocator. A key names one
-	// `(variant, amount)` pair, so the scatter below accumulates straight into it.
-	let mut multilinear = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
+) -> Box<[F]> {
+	// One zeroed row per shift the segment uses. A key names one such row, so the accumulation
+	// below adds straight into it.
+	let mut rows = vec![F::ZERO; segment.dense_shift_enc.len() * Word::BITS].into_boxed_slice();
 
 	// Each folded word carries the keys named by the segment-relative range at its position.
 	for (word, range) in folded_words.iter().zip(&segment.key_ranges) {
@@ -180,11 +178,8 @@ pub fn build_g_from_folded_words<F: BinaryField, A: Allocator>(
 				&operator_data.lambda_powers,
 			);
 
-			// The key's shift variant indexes the high variables and its shift amount the middle
-			// ones, which together name one run of bit slots.
-			let (variant, amount) = segment.dense_shift_enc.decode(key.dense_shift_idx as usize);
-			let base = (variant as usize * Word::BITS + amount as usize) * Word::BITS;
-			let slots = &mut multilinear.as_mut()[base..base + Word::BITS];
+			let base = key.dense_shift_idx as usize * Word::BITS;
+			let slots = &mut rows[base..base + Word::BITS];
 
 			// Scatter the accumulator across this key's bit slots, scaling each by the folded bit.
 			for (slot, &folded_bit) in iter::zip(slots, word) {
@@ -193,7 +188,7 @@ pub fn build_g_from_folded_words<F: BinaryField, A: Allocator>(
 		}
 	}
 
-	multilinear
+	rows
 }
 
 #[cfg(test)]
@@ -207,12 +202,13 @@ mod tests {
 	};
 	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
 	use binius_math::{
-		inner_product::inner_product_buffers,
 		multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
 		test_utils::random_scalars,
 		univariate::lagrange_evals_scalars,
 	};
-	use binius_prover::protocols::shift::{OperatorData, build_key_collection, monster::build_h};
+	use binius_prover::protocols::shift::{
+		DenseShiftEncoding, OperatorData, build_key_collection, monster::build_h,
+	};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
 		config::{B128, StdChallenger},
@@ -484,26 +480,27 @@ mod tests {
 		};
 		let prepared = claims.prepare(|| B128::random(&mut rng));
 
-		// The g multilinear: the public segment folds from raw constant words via the
-		// single-instance builder, the hidden segment from the instance-folded words. Add them.
-		// The h multilinear comes from the single-instance prover.
-		let mut g = build_g::<B128, B128, _>(
-			&GlobalAllocator,
-			public_words,
-			&key_collection.public,
-			&prepared,
-		);
-		let hidden_g = build_g_from_folded_words(
-			&GlobalAllocator,
-			&hidden_folded,
-			&key_collection.hidden,
-			&prepared,
-		);
-		for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
-			*slot += *add;
-		}
+		// The g rows: the public segment folds from raw constant words via the single-instance
+		// builder, the hidden segment from the instance-folded words. The h multilinear comes
+		// from the single-instance prover.
+		let public = build_g::<B128, B128>(public_words, &key_collection.public, &prepared);
+		let hidden = build_g_from_folded_words(&hidden_folded, &key_collection.hidden, &prepared);
 		let h = build_h::<B128, B128, _>(&GlobalAllocator, &domain_subspace, r_z);
-		let inner_product = inner_product_buffers(&g, &h);
+
+		// `g` is zero outside the rows the segments name, so the inner product is those rows
+		// alone — each sitting at `shift_index * Word::BITS` in the phase-1 layout.
+		let segment_inner_product = |rows: &[B128], enc: &DenseShiftEncoding| {
+			iter::zip(enc.shift_indices(), rows.chunks_exact(Word::BITS))
+				.map(|(shift_index, row)| {
+					let base = shift_index * Word::BITS;
+					iter::zip(row, base..)
+						.map(|(&value, index)| value * h.get(index))
+						.sum::<B128>()
+				})
+				.sum::<B128>()
+		};
+		let inner_product = segment_inner_product(&public, &key_collection.public.dense_shift_enc)
+			+ segment_inner_product(&hidden, &key_collection.hidden.dense_shift_enc);
 
 		// The lambda-powers scaling of the batched AND-check evals, plus the empty intmul claim.
 		let expected = prepared.bitand.batched_eval + prepared.intmul.batched_eval;

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -1,8 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::iter;
-
 use binius_circuits::sha256::sha256_fixed;
 use binius_compute::{BufferPool, GlobalAllocator};
 use binius_core::{
@@ -19,7 +17,7 @@ use binius_prover::{
 	protocols::shift::{
 		OperatorClaims, OperatorData, build_key_collection,
 		monster::{build_h, build_monster_segments},
-		phase_1::{build_g, run_phase_1_sumcheck},
+		phase_1::{SparseShiftRows, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 		prove,
 	},
@@ -300,17 +298,15 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// here (with a throwaway transcript) to capture each phase's inputs; the setup closures below
 	// then only clone what a phase consumes by value. The specific transcript challenges do not
 	// change the work a phase performs.
-	// `build_g` runs per key segment; the full g multilinear is the sum of the public and
-	// hidden segment ones.
+	// `build_g` runs per key segment; the full g multilinear is the two segments' entries
+	// concatenated, as `prove_phase_1` assembles them.
 	let build_combined_g = || {
-		let mut g =
-			build_g::<F, P, _>(&GlobalAllocator, public_words, &key_collection.public, &prepared);
-		let hidden_g =
-			build_g::<F, P, _>(&GlobalAllocator, hidden_words, &key_collection.hidden, &prepared);
-		for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
-			*slot += *add;
-		}
-		g
+		let public = build_g::<F, P>(public_words, &key_collection.public, &prepared);
+		let hidden = build_g::<F, P>(hidden_words, &key_collection.hidden, &prepared);
+		SparseShiftRows::from_segments([
+			(&public, &key_collection.public.dense_shift_enc),
+			(&hidden, &key_collection.hidden.dense_shift_enc),
+		])
 	};
 
 	let g = build_combined_g();

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -107,6 +107,14 @@ impl DenseShiftEncoding {
 		self.shifts.iter().copied()
 	}
 
+	/// Where every shift the segment uses sits in the full space of `SHIFT_PAIR_COUNT` shifts, in
+	/// dense index order.
+	///
+	/// The indices are strictly increasing, which is what lets two segments' encodings merge.
+	pub fn shift_indices(&self) -> impl Iterator<Item = usize> + '_ {
+		self.shifts.iter().map(|&shift| shift_index(shift))
+	}
+
 	/// The dense index of every shift, for lookup while the keys are built.
 	///
 	/// The entries of the shifts the segment does not use are meaningless.

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -1,17 +1,26 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, ops::Range};
+use std::{
+	iter,
+	ops::{Deref, Range},
+};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, PackedField};
-use binius_ip::sumcheck::SumcheckOutput;
+use binius_field::{BinaryField, Field, PackedField, WideMul};
+use binius_ip::sumcheck::{RoundCoeffs, SumcheckOutput};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{ProveSingleOutput, bivariate_product_prover, prove_single},
+	sumcheck::{
+		ProveSingleOutput, bivariate_product_evaluator::BivariateProductEvaluator,
+		bivariate_product_prover, common::SumcheckProver, prove_single, round_evals::RoundEvals,
+		round_evaluator::SharedSumcheckProver,
+	},
 };
-use binius_math::{BinarySubspace, FieldBuffer, FieldVec};
+use binius_math::{
+	BinarySubspace, FieldBuffer, FieldVec, multilinear::fold::fold_highest_var_inplace,
+};
 use binius_utils::rayon::{
 	prelude::*,
 	task_size::{IndexedParallelIteratorExt, WorkPerItem},
@@ -34,6 +43,13 @@ use super::{
 /// amount, and the shift variant.
 pub const PHASE_1_LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS + LOG_SHIFT_VARIANT_COUNT;
 
+/// The number of variables of the phase-1 multilinears that index the shift.
+///
+/// Both multilinears hold one row of `Word::BITS` scalars per `(shift variant, shift amount)`
+/// pair, the bit position running within a row. These are the variables above that row: the shift
+/// amount, then the shift variant.
+pub const LOG_SHIFT_ROWS: usize = PHASE_1_LOG_LEN - Word::LOG_BITS;
+
 /// Proves the first phase of the shift reduction.
 ///
 /// Builds the g and h multilinears and runs one sumcheck over their product.
@@ -52,13 +68,14 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	// Build the g multilinear for the public and hidden segments separately, then sum them. The
+	// Accumulate the g rows of the public and hidden segments separately, then collect both. The
 	// public words are the prefix of `words`, and each segment's key ranges are segment-relative.
-	let mut g = build_g::<_, P, _>(alloc, words.public, &key_collection.public, prepared);
-	let hidden_g = build_g::<_, P, _>(alloc, words.hidden, &key_collection.hidden, prepared);
-	for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
-		*slot += *add;
-	}
+	let public = build_g::<_, P>(words.public, &key_collection.public, prepared);
+	let hidden = build_g::<_, P>(words.hidden, &key_collection.hidden, prepared);
+	let g = SparseShiftRows::from_segments([
+		(&public, &key_collection.public.dense_shift_enc),
+		(&hidden, &key_collection.hidden.dense_shift_enc),
+	]);
 
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
 	let h = build_h(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
@@ -66,11 +83,286 @@ where
 	run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
 }
 
+/// The number of packed elements one row of `Word::BITS` scalars occupies.
+const fn row_len<P: PackedField>() -> usize {
+	assert!(
+		P::LOG_WIDTH <= Word::LOG_BITS,
+		"a row of `Word::BITS` scalars must be a whole number of packed elements"
+	);
+	Word::BITS >> P::LOG_WIDTH
+}
+
+/// The rows of the phase-1 `g` multilinear that a constraint system's shifts reach.
+///
+/// `g` spans one row of `Word::BITS` scalars per `(shift variant, shift amount)` pair, of which a
+/// constraint system names a few dozen out of the `1 << LOG_SHIFT_ROWS` the space holds — 16 for a
+/// SHA256 circuit, 40 for Keccak. Only the named rows are stored, each tagged with its row index.
+///
+/// `g` is the sum of its stored rows, so **rows at a repeated index add up and need not be
+/// deduplicated**. That is what lets the two key segments' rows simply concatenate, and what keeps
+/// the list a flat run of the same length for the whole protocol.
+#[derive(Debug, Clone)]
+pub struct SparseShiftRows<P: PackedField> {
+	/// The row index of each stored row, in `values` order and below `1 << log_rows`. Repeatable.
+	indices: Vec<u32>,
+	/// The stored rows end to end, [`row_len`] packed elements each, in `indices` order.
+	values: Vec<P>,
+	/// The number of row-index variables the sumcheck has yet to bind.
+	log_rows: usize,
+}
+
+impl<P: PackedField> SparseShiftRows<P> {
+	/// Collects the rows two key segments accumulated, tagged with the shift index each sits at.
+	///
+	/// Each segment's rows arrive in its own dense shift index order, which its encoding decodes to
+	/// the shift indices this list keys on. The two segments concatenate: a shift both of them use
+	/// contributes one row each at the same index, and the two add up where `g` is read.
+	///
+	/// # Panics
+	///
+	/// Panics unless each segment's rows number exactly what its encoding accounts for.
+	pub fn from_segments(segments: [(&[P], &DenseShiftEncoding); 2]) -> Self {
+		let mut indices = Vec::new();
+		let mut values = Vec::new();
+		for (rows, dense_shift_enc) in segments {
+			assert_eq!(
+				rows.len(),
+				dense_shift_enc.len() * row_len::<P>(),
+				"a segment holds one row per shift its encoding names"
+			);
+			indices.extend(dense_shift_enc.shift_indices().map(|index| index as u32));
+			values.extend_from_slice(rows);
+		}
+
+		Self {
+			indices,
+			values,
+			log_rows: LOG_SHIFT_ROWS,
+		}
+	}
+
+	/// The number of row-index variables the sumcheck has yet to bind.
+	const fn log_rows(&self) -> usize {
+		self.log_rows
+	}
+
+	/// The stored rows, each with the row index it sits at.
+	fn rows(&self) -> impl Iterator<Item = (usize, &[P])> {
+		iter::zip(&self.indices, self.values.chunks_exact(row_len::<P>()))
+			.map(|(&index, row)| (index as usize, row))
+	}
+
+	/// The index-space bit the next round binds, separating the two halves of the row space.
+	///
+	/// ## Preconditions
+	///
+	/// * `self.log_rows() >= 1`
+	fn half(&self) -> usize {
+		assert!(self.log_rows > 0, "precondition: a row-index variable remains to bind");
+		1 << (self.log_rows - 1)
+	}
+
+	/// Binds the highest row-index variable to a challenge.
+	///
+	/// Folding is linear in `g`, so a row keeps its identity across it: it is scaled by the
+	/// challenge weight of the half it sits in and moved down into the folded index space. The list
+	/// therefore stays the same length, and nothing has to be paired up or merged.
+	///
+	/// ## Preconditions
+	///
+	/// * `self.log_rows() >= 1`
+	fn fold(&mut self, challenge: P::Scalar) {
+		let half = self.half();
+		let lower_weight = P::broadcast(P::Scalar::ONE - challenge);
+		let upper_weight = P::broadcast(challenge);
+
+		let row_len = row_len::<P>();
+		for (position, index) in self.indices.iter_mut().enumerate() {
+			let row = &mut self.values[position * row_len..][..row_len];
+			if *index as usize & half == 0 {
+				row.iter_mut().for_each(|value| *value *= lower_weight);
+			} else {
+				row.iter_mut().for_each(|value| *value *= upper_weight);
+				*index ^= half as u32;
+			}
+		}
+
+		self.log_rows -= 1;
+	}
+
+	/// What is left of `g` once every row-index variable is bound: one dense row over the bit
+	/// position, the sum of the stored rows now that they all sit at the one remaining index.
+	///
+	/// ## Preconditions
+	///
+	/// * `self.log_rows() == 0`
+	fn into_bit_multilinear<A: Allocator>(self, alloc: &A) -> FieldVec<P, A> {
+		assert_eq!(self.log_rows, 0, "precondition: every row-index variable is bound");
+
+		let mut multilinear = FieldBuffer::zeros_in(alloc, Word::LOG_BITS);
+		for (_, row) in self.rows() {
+			for (slot, &value) in iter::zip(multilinear.as_mut(), row) {
+				*slot += value;
+			}
+		}
+		multilinear
+	}
+}
+
+/// Proves the phase-1 sumcheck: the product of `g` and `h` summed over the hypercube.
+///
+/// `g` is zero outside the rows a constraint system's shifts name, but *within* a named row it is
+/// dense — every one of the `Word::BITS` bit positions carries a value. Its sparsity is in long
+/// strides rather than scattered points, so the prover changes strategy halfway:
+///
+/// - The [`LOG_SHIFT_ROWS`] rounds binding the row index read the stored rows alone
+///   ([`SparseShiftRows`]), so their cost follows the shifts the system names rather than the 512
+///   the space holds. `h` stays dense across them and folds as any multilinear does, which is what
+///   keeps this simple: a round reads `h` at whichever row a live `g` row pairs with, so nothing
+///   has to work out in advance which rows of `h` a later round will reach.
+/// - Once the row index is bound, both multilinears are one dense row over the bit position and no
+///   sparsity is left to exploit. The shared [`bivariate_product_prover`] runs the remaining
+///   `Word::LOG_BITS` rounds.
+///
+/// Every round message is the one a dense prover over the whole of `g` would have sent, so the
+/// transcript is unchanged and the verifier is untouched.
+///
+/// This adapts `SparseDenseProductSumcheckProver` to that stride structure, and inherits its
+/// central simplification: both sampled evaluations and the fold are linear in `g`, so a stored
+/// row contributes on its own and rows never have to be paired across the split or merged. That
+/// prover keys on single points, which costs a pass over `n_shifts * Word::BITS` entries in
+/// *every* round; keying on rows lets a round walk whole packed rows instead.
+pub struct Phase1SumcheckProver<'alloc, A: Allocator, P: PackedField> {
+	alloc: &'alloc A,
+	/// The stage the protocol is in.
+	///
+	/// Always `Some` between calls. [`SumcheckProver::fold`] takes it out for the moment it moves
+	/// the row stage's buffers into the bit stage's prover.
+	stage: Option<Stage<'alloc, A, P>>,
+}
+
+/// Which half of the protocol the prover is in.
+enum Stage<'alloc, A: Allocator, P: PackedField> {
+	/// Binding the row index, over the rows `g` stores.
+	Rows {
+		g: SparseShiftRows<P>,
+		h: FieldVec<P, A>,
+		/// This round's sum claim.
+		claim: P::Scalar,
+		/// The round polynomial, once `execute` has produced it and while it awaits the challenge
+		/// that reduces it to the next claim.
+		coeffs: Option<RoundCoeffs<P::Scalar>>,
+	},
+	/// Binding the bit position, both multilinears now one dense row.
+	Bits(SharedSumcheckProver<'alloc, A, P, BivariateProductEvaluator>),
+}
+
+impl<'alloc, A: Allocator, F: Field, P: PackedField<Scalar = F>>
+	Phase1SumcheckProver<'alloc, A, P>
+{
+	/// Creates a prover for the claim that `g * h` sums to `sum` over the hypercube.
+	///
+	/// # Panics
+	///
+	/// Panics unless `g` and `h` both span the whole phase-1 hypercube.
+	pub fn new(g: SparseShiftRows<P>, h: FieldVec<P, A>, sum: F, alloc: &'alloc A) -> Self {
+		assert_eq!(h.log_len(), PHASE_1_LOG_LEN, "h spans the whole phase-1 hypercube");
+		assert_eq!(g.log_rows(), LOG_SHIFT_ROWS, "g spans the whole shift space");
+
+		Self {
+			alloc,
+			stage: Some(Stage::Rows {
+				g,
+				h,
+				claim: sum,
+				coeffs: None,
+			}),
+		}
+	}
+}
+
+impl<A: Allocator, F: Field, P: PackedField<Scalar = F>> SumcheckProver<F>
+	for Phase1SumcheckProver<'_, A, P>
+{
+	fn n_vars(&self) -> usize {
+		match self.stage.as_ref().expect("the stage is set between calls") {
+			// `h` spans both axes through the row rounds, so its length is what remains.
+			Stage::Rows { h, .. } => h.log_len(),
+			Stage::Bits(prover) => prover.n_vars(),
+		}
+	}
+
+	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
+		match self.stage.as_mut().expect("the stage is set between calls") {
+			Stage::Rows {
+				g,
+				h,
+				claim,
+				coeffs,
+			} => {
+				let round_coeffs = shift_round_coeffs(g, h, *claim);
+				*coeffs = Some(round_coeffs.clone());
+				vec![round_coeffs]
+			}
+			Stage::Bits(prover) => prover.execute(),
+		}
+	}
+
+	fn fold(&mut self, challenge: F) {
+		// Taken out so the row stage's buffers can move into the bit stage's prover below.
+		let stage = self.stage.take().expect("the stage is set between calls");
+		self.stage = Some(match stage {
+			Stage::Rows {
+				mut g,
+				mut h,
+				coeffs,
+				..
+			} => {
+				let claim = coeffs
+					.expect("execute is called before fold")
+					.evaluate(&challenge);
+				g.fold(challenge);
+				fold_highest_var_inplace(&mut h, challenge);
+
+				if g.log_rows() > 0 {
+					Stage::Rows {
+						g,
+						h,
+						claim,
+						coeffs: None,
+					}
+				} else {
+					// The row index is bound. What is left of each multilinear is one dense row
+					// over the bit position, which the shared prover handles from here.
+					Stage::Bits(bivariate_product_prover(
+						self.alloc,
+						[g.into_bit_multilinear(self.alloc), h],
+						claim,
+					))
+				}
+			}
+			Stage::Bits(mut prover) => {
+				prover.fold(challenge);
+				Stage::Bits(prover)
+			}
+		});
+	}
+
+	fn finish(self) -> Vec<F> {
+		match self.stage.expect("the stage is set between calls") {
+			Stage::Rows { .. } => panic!("finish called before the row index was bound"),
+			// The columns went in as `[g, h]`, so the evaluations come out in that order.
+			Stage::Bits(prover) => prover.finish(),
+		}
+	}
+}
+
 /// Runs the phase 1 sumcheck protocol for shift constraint verification.
 ///
-/// One bivariate-product sumcheck over `g` and `h`, both multilinears of [`PHASE_1_LOG_LEN`]
-/// variables. The shift variant is the high [`LOG_SHIFT_VARIANT_COUNT`] variables of each, so the
-/// sumcheck folds the variant axis rather than the prover summing a separate claim per variant.
+/// One sumcheck over the product of `g` and `h`, multilinears of [`PHASE_1_LOG_LEN`] variables,
+/// driven by [`Phase1SumcheckProver`]. The shift variant is the high
+/// [`LOG_SHIFT_VARIANT_COUNT`] variables of each, so the sumcheck folds the variant axis rather
+/// than the prover summing a separate claim per variant.
 ///
 /// The `g` multilinear carries the witness and the batching randomness; `h` encodes what each
 /// shift does at the univariate challenge point.
@@ -96,18 +388,16 @@ pub fn run_phase_1_sumcheck<
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 >(
-	g: FieldVec<P, A>,
+	g: SparseShiftRows<P>,
 	h: FieldVec<P, A>,
 	sum: F,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> SumcheckOutput<F> {
-	let prover = bivariate_product_prover(alloc, [g, h], sum);
-
 	let ProveSingleOutput {
 		multilinear_evals,
 		mut challenges,
-	} = prove_single(prover, channel);
+	} = prove_single(Phase1SumcheckProver::new(g, h, sum, alloc), channel);
 	challenges.reverse();
 
 	let [g_eval, h_eval] = multilinear_evals
@@ -120,46 +410,89 @@ pub fn run_phase_1_sumcheck<
 	}
 }
 
-/// Constructs the phase-1 "g" multilinear for one key segment.
+/// Computes one round message of the phase-1 sumcheck over the row index.
 ///
-/// This builds the g multilinear polynomials used in phase 1 of the shift protocol, over the words
-/// of a single value-vector segment (public or hidden). It constructs one multilinear polynomial
-/// per shift variant.
+/// The round polynomial is sampled at 1 and at infinity, as [`RoundEvals`] documents; the claim
+/// supplies its value at 0. Both are linear in `g`, so each stored row contributes on its own and
+/// rows facing each other across the split never have to be paired:
+///
+/// ```text
+/// R(1)   = sum_v G_1(v) H_1(v)             row (i, c) adds <c, h[i]>, upper half only
+/// R(inf) = sum_v (G_0 + G_1)(H_0 + H_1)    row (i, c) adds <c, h[i] + h[i ^ half]>, either half
+/// ```
+///
+/// `h` is dense, so the row facing a stored row is always there to read.
+fn shift_round_coeffs<F, P, Data>(
+	g: &SparseShiftRows<P>,
+	h: &FieldBuffer<P, Data>,
+	claim: F,
+) -> RoundCoeffs<F>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	Data: Deref<Target = [P]>,
+{
+	let half = g.half();
+	let row_len = row_len::<P>();
+	let h_rows = h.as_ref();
+
+	// The per-point products accumulate in unreduced (wide) form and reduce once at the end.
+	let mut y_1 = <P as WideMul>::Output::default();
+	let mut y_inf = <P as WideMul>::Output::default();
+	for (index, row) in g.rows() {
+		let own = &h_rows[index * row_len..][..row_len];
+		let facing = &h_rows[(index ^ half) * row_len..][..row_len];
+
+		for i in 0..row_len {
+			// The infinity evaluation reads H(0) + H(1), the same sum from either half, so the
+			// row's own half only decides the evaluation at 1.
+			if index & half != 0 {
+				y_1 += P::wide_mul(row[i], own[i]);
+			}
+			y_inf += P::wide_mul(row[i], own[i] + facing[i]);
+		}
+	}
+
+	// A row is a whole number of packed elements, so every lane of the accumulators is live.
+	let sum_lanes = |wide| P::reduce(wide).iter().sum::<F>();
+	RoundEvals([sum_lanes(y_1), sum_lanes(y_inf)]).interpolate(claim)
+}
+
+/// Accumulates the phase-1 "g" rows of one key segment.
+///
+/// This builds the rows of the g multilinear used in phase 1 of the shift protocol, over the words
+/// of a single value-vector segment (public or hidden).
 ///
 /// The value vector's public and hidden words participate through their own [`KeySegment`], so a
-/// caller builds each segment's parts with the matching words and sums the two results.
+/// caller accumulates each segment's rows with the matching words and merges the two results with
+/// [`SparseShiftRows::from_segments`].
 ///
 /// # Construction Process
 ///
 /// 1. **Parallel Processing**: Words are processed in parallel chunks for efficiency
 /// 2. **Key Processing**: For each word, iterate through its associated keys in the segment
 /// 3. **Accumulation**: For each key, accumulate its contribution weighted by the r_x' tensor
-/// 4. **Word Expansion**: Expand each witness word bitwise to populate the g multilinears
+/// 4. **Word Expansion**: Expand each witness word bitwise to populate the g rows
 /// 5. **Lambda Weighting**: Apply lambda powers to weight different operand positions
-///
-/// The accumulator holds one row of `Word::BITS` scalars per shift the segment uses, addressed by
-/// the keys' dense shift index. A scatter through the segment's encoding then spreads those rows
-/// over the full `(shift variant, shift amount)` space of the returned parts.
 ///
 /// # Returns
 ///
-/// One multilinear of [`PHASE_1_LOG_LEN`] variables holding every shift variant's part: the
-/// variant indexes the high [`LOG_SHIFT_VARIANT_COUNT`] variables, and within a variant the rows
-/// of `Word::BITS` scalars run in order of shift amount.
+/// One row of `Word::BITS` scalars per shift the segment uses, addressed by the keys' dense shift
+/// index. The segment's [`DenseShiftEncoding`] decodes that index to the `(variant, amount)` pair
+/// the row belongs to, and so to the row's place in the full shift space.
 ///
 /// # Usage
 ///
-/// Used in phase 1 to construct the constant size g multilinears
+/// Used in phase 1 to construct the constant size g multilinear
 /// that will participate in the phase 1 sumcheck protocol.
 #[instrument(skip_all, name = "build_g")]
-pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
-	alloc: &A,
+pub fn build_g<F: Field, P: PackedField<Scalar = F>>(
 	words: &[Word],
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
-) -> FieldVec<P, A> {
+) -> Box<[P]> {
 	// One row of `Word::BITS` scalars per shift the segment uses.
-	let row_len = Word::BITS >> P::LOG_WIDTH;
+	let row_len = row_len::<P>();
 	let acc_size = segment.dense_shift_enc.len() * row_len;
 
 	const {
@@ -178,7 +511,7 @@ pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	let low_bits_mask = (1u8 << P::WIDTH) - 1;
 
 	// Each word carries the keys named by the segment-relative range at its position.
-	let multilinears = words
+	words
 		.par_iter()
 		.zip(segment.key_ranges.par_iter())
 		.with_min_task(WorkPerItem::FieldMuls)
@@ -251,39 +584,297 @@ pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 			});
 			acc
 		})
-		// An empty word list yields no partials at all, and its parts are zero.
-		.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice());
-
-	scatter_shift_rows(alloc, &multilinears, &segment.dense_shift_enc)
+		// An empty word list yields no partials at all, and its rows are zero.
+		.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice())
 }
 
-/// Spreads the rows of a dense phase-1 accumulator over the shift axes of the g multilinear.
-///
-/// The accumulator holds the rows of `Word::BITS` scalars the segment's keys accumulate into, one
-/// per shift the segment uses and in dense shift index order. Each row lands at the offset its
-/// `(variant, amount)` pair names; every row the segment does not use stays zero.
-#[instrument(skip_all, name = "scatter_shift_rows")]
-fn scatter_shift_rows<P: PackedField, A: Allocator>(
-	alloc: &A,
-	multilinears: &[P],
-	dense_shift_enc: &DenseShiftEncoding,
-) -> FieldVec<P, A> {
-	const {
-		assert!(
-			P::LOG_WIDTH <= Word::LOG_BITS,
-			"P::WIDTH is not supposed to exceed 8, so this statement must hold"
-		);
+#[cfg(test)]
+mod tests {
+	use binius_compute::GlobalAllocator;
+	use binius_core::{
+		ShiftVariant,
+		constraint_system::{
+			AndConstraint, ConstraintSystem, InoutSegment, ShiftedValueIndex, ValueIndex,
+		},
+	};
+	use binius_field::{
+		AESTowerField8b, BinaryField128bGhash, Field, PackedBinaryGhash2x128b, Random,
+	};
+	use binius_math::inner_product::inner_product_buffers;
+	use binius_transcript::ProverTranscript;
+	use binius_verifier::config::StdChallenger;
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::protocols::shift::key_collection::build_key_collection;
+
+	type F = BinaryField128bGhash;
+
+	impl<P: PackedField> SparseShiftRows<P> {
+		/// Spreads the rows over the full shift space, as a dense multilinear of
+		/// [`PHASE_1_LOG_LEN`] variables. Rows at a repeated index add up; every row the system
+		/// does not name stays zero.
+		///
+		/// The prover never needs this — [`Phase1SumcheckProver`] reads the rows where they are.
+		/// It is the dense `g` these tests measure the sparse rounds against.
+		///
+		/// ## Preconditions
+		///
+		/// * `self.log_rows() == LOG_SHIFT_ROWS`, so the rows still span the whole shift space
+		fn scatter<A: Allocator>(&self, alloc: &A) -> FieldVec<P, A> {
+			assert_eq!(
+				self.log_rows, LOG_SHIFT_ROWS,
+				"precondition: no row-index variable is bound"
+			);
+
+			let row_len = row_len::<P>();
+			let mut g = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
+			for (index, row) in self.rows() {
+				// A row is a whole number of packed elements, so it lands at row alignment.
+				let slots = &mut g.as_mut()[index * row_len..][..row_len];
+				for (slot, &value) in iter::zip(slots, row) {
+					*slot += value;
+				}
+			}
+			g
+		}
 	}
 
-	// A row is a whole number of packed elements, so it copies in at row alignment.
-	let row_len = Word::BITS >> P::LOG_WIDTH;
-	let mut g = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
-	for ((variant, amount), row) in iter::zip(dense_shift_enc.iter(), multilinears.chunks(row_len))
-	{
-		// The variant indexes the high variables and the amount the middle ones. Dense indices are
-		// distinct, so no two rows land in the same place and each destination is still zero.
-		let offset = (variant as usize * Word::BITS + amount as usize) * row_len;
-		g.as_mut()[offset..][..row_len].copy_from_slice(row);
+	/// A system whose two segments name overlapping but distinct shifts.
+	///
+	/// The public segment names `(Sll, 0)` and `(Slr, 3)`; the hidden one `(Sll, 0)`, `(Sar, 7)`
+	/// and `(Rotr, 1)`. So `(Sll, 0)` is the shift the merge has to sum across segments.
+	fn overlapping_shift_system() -> ConstraintSystem {
+		let public = ValueIndex::constant(1);
+		let hidden = ValueIndex::private(1);
+		ConstraintSystem {
+			constants: vec![Word::ZERO; 4],
+			n_inout: 0,
+			n_private: 4,
+			zero_constraints: Vec::new(),
+			and_constraints: vec![AndConstraint([
+				vec![
+					ShiftedValueIndex::plain(public),
+					ShiftedValueIndex::srl(public, 3),
+				],
+				vec![ShiftedValueIndex::sar(hidden, 7)],
+				vec![
+					ShiftedValueIndex::rotr(hidden, 1),
+					ShiftedValueIndex::plain(hidden),
+				],
+			])],
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		}
 	}
-	g
+
+	/// The two segments' rows concatenate, each tagged with the shift index it sits at.
+	///
+	/// A shift both segments name appears twice rather than being merged — `g` is the sum of its
+	/// rows, so the two add up wherever it is read, and nothing has to deduplicate them.
+	#[test]
+	fn from_segments_concatenates_the_two_encodings() {
+		let key_collection =
+			build_key_collection(&overlapping_shift_system(), InoutSegment::Public);
+
+		// Fill each segment's rows with a distinct constant per row, so a row's value says which
+		// segment it came from.
+		let segment_rows = |enc: &DenseShiftEncoding, base: u128| {
+			(0..enc.len() * Word::BITS)
+				.map(|i| F::new(base + (i / Word::BITS) as u128))
+				.collect::<Vec<F>>()
+		};
+		let public = segment_rows(&key_collection.public.dense_shift_enc, 0x100);
+		let hidden = segment_rows(&key_collection.hidden.dense_shift_enc, 0x200);
+
+		let g = SparseShiftRows::from_segments([
+			(&public, &key_collection.public.dense_shift_enc),
+			(&hidden, &key_collection.hidden.dense_shift_enc),
+		]);
+
+		// The public segment's two shifts, then the hidden segment's three. `(Sll, 0)` is the first
+		// row of both, so index 0 appears twice.
+		let shift_index = |variant: ShiftVariant, amount: usize| {
+			variant as u32 * Word::BITS as u32 + amount as u32
+		};
+		assert_eq!(
+			g.indices,
+			[
+				shift_index(ShiftVariant::Sll, 0),
+				shift_index(ShiftVariant::Slr, 3),
+				shift_index(ShiftVariant::Sll, 0),
+				shift_index(ShiftVariant::Sar, 7),
+				shift_index(ShiftVariant::Rotr, 1),
+			]
+		);
+
+		// Each row is the one its own segment accumulated, untouched by the other's.
+		let row = |position: usize| &g.values[position * Word::BITS..][..Word::BITS];
+		for (position, expected) in [0x100, 0x101, 0x200, 0x201, 0x202].into_iter().enumerate() {
+			assert!(row(position).iter().all(|&value| value == F::new(expected)));
+		}
+
+		// Where `g` is read, the two rows at `(Sll, 0)` add up.
+		let dense = g.scatter(&GlobalAllocator);
+		let at = |variant: ShiftVariant, amount: usize| {
+			dense.get((variant as usize * Word::BITS + amount) * Word::BITS)
+		};
+		assert_eq!(at(ShiftVariant::Sll, 0), F::new(0x100) + F::new(0x200));
+		assert_eq!(at(ShiftVariant::Slr, 3), F::new(0x101));
+		assert_eq!(at(ShiftVariant::Sar, 7), F::new(0x201));
+		assert_eq!(at(ShiftVariant::Rotr, 1), F::new(0x202));
+	}
+
+	/// The scatter puts every row where its shift index names, and leaves the rest zero.
+	#[test]
+	fn scatter_places_rows_at_their_shift_index() {
+		let key_collection =
+			build_key_collection(&overlapping_shift_system(), InoutSegment::Public);
+		let hidden_enc = &key_collection.hidden.dense_shift_enc;
+
+		// One non-zero row per shift the hidden segment names, and an empty public segment.
+		let hidden = (0..hidden_enc.len() * Word::BITS)
+			.map(|i| F::new(1 + (i / Word::BITS) as u128))
+			.collect::<Vec<F>>();
+		let merged = SparseShiftRows::<F>::from_segments([
+			(&[], &DenseShiftEncoding::default()),
+			(&hidden, hidden_enc),
+		]);
+
+		let g = merged.scatter(&binius_compute::GlobalAllocator);
+		assert_eq!(g.log_len(), PHASE_1_LOG_LEN);
+
+		// Exactly the named rows are non-zero, and each holds what the merged list held.
+		for (row, (variant, amount)) in hidden_enc.iter().enumerate() {
+			let offset = (variant as usize * Word::BITS + amount as usize) * Word::BITS;
+			for bit in 0..Word::BITS {
+				assert_eq!(g.get(offset + bit), F::new(1 + row as u128));
+			}
+		}
+		let named = hidden_enc
+			.iter()
+			.map(|(variant, amount)| variant as usize * Word::BITS + amount as usize)
+			.collect::<Vec<_>>();
+		for row in (0..1 << LOG_SHIFT_ROWS).filter(|row| !named.contains(row)) {
+			assert!((0..Word::BITS).all(|bit| g.get(row * Word::BITS + bit) == F::ZERO));
+		}
+	}
+
+	/// Runs the phase-1 sumcheck the dense way: one bivariate-product prover over the scattered
+	/// `g` and the whole of `h`, with no round of it special-cased.
+	///
+	/// This is what [`run_phase_1_sumcheck`] replaces, kept here as the reference its round
+	/// messages have to reproduce.
+	fn run_dense_reference<P: PackedField<Scalar = F>>(
+		g: &SparseShiftRows<P>,
+		h: FieldVec<P, GlobalAllocator>,
+		sum: F,
+		channel: &mut ProverTranscript<StdChallenger>,
+	) -> SumcheckOutput<F> {
+		let prover =
+			bivariate_product_prover(&GlobalAllocator, [g.scatter(&GlobalAllocator), h], sum);
+
+		let ProveSingleOutput {
+			multilinear_evals,
+			mut challenges,
+		} = prove_single(prover, channel);
+		challenges.reverse();
+
+		let [g_eval, h_eval] = multilinear_evals
+			.try_into()
+			.expect("prover has 2 multilinear polynomials");
+
+		SumcheckOutput {
+			challenges,
+			eval: g_eval * h_eval,
+		}
+	}
+
+	/// The phase-1 `g` and `h` of a constraint system, at a pseudo-random univariate challenge.
+	///
+	/// `g`'s rows carry arbitrary values rather than ones a witness produces: the sumcheck is a
+	/// statement about whatever multilinears it is handed, so what the rows hold does not bear on
+	/// whether the sparse rounds reproduce the dense ones.
+	fn phase_1_multilinears<P: PackedField<Scalar = F>>(
+		cs: &ConstraintSystem,
+		seed: u64,
+	) -> (SparseShiftRows<P>, FieldVec<P, GlobalAllocator>) {
+		let mut rng = StdRng::seed_from_u64(seed);
+		let key_collection = build_key_collection(cs, InoutSegment::Public);
+
+		let segment_rows = |enc: &DenseShiftEncoding, rng: &mut StdRng| {
+			(0..enc.len() * row_len::<P>())
+				.map(|_| P::random(&mut *rng))
+				.collect::<Vec<P>>()
+		};
+		let public = segment_rows(&key_collection.public.dense_shift_enc, &mut rng);
+		let hidden = segment_rows(&key_collection.hidden.dense_shift_enc, &mut rng);
+		let g = SparseShiftRows::from_segments([
+			(&public, &key_collection.public.dense_shift_enc),
+			(&hidden, &key_collection.hidden.dense_shift_enc),
+		]);
+
+		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
+		let h = build_h(&GlobalAllocator, &subspace, F::random(&mut rng));
+
+		(g, h)
+	}
+
+	/// The sparse rounds send exactly what the dense prover sends.
+	///
+	/// The two provers sum the same product over the same hypercube, so every round message — and
+	/// therefore the whole transcript, the challenges it draws, and the evaluation it reduces to —
+	/// must agree. This is what lets the verifier stay untouched.
+	fn assert_sparse_matches_dense<P: PackedField<Scalar = F>>(cs: &ConstraintSystem, seed: u64) {
+		let (g, h) = phase_1_multilinears::<P>(cs, seed);
+		// The true sum, so the test exercises a sumcheck a verifier would accept.
+		let sum = inner_product_buffers(&g.scatter(&GlobalAllocator), &h);
+
+		let mut sparse_transcript = ProverTranscript::<StdChallenger>::default();
+		let sparse = run_phase_1_sumcheck::<F, P, _, _>(
+			g.clone(),
+			h.clone(),
+			sum,
+			&mut sparse_transcript,
+			&GlobalAllocator,
+		);
+
+		let mut dense_transcript = ProverTranscript::<StdChallenger>::default();
+		let dense = run_dense_reference(&g, h, sum, &mut dense_transcript);
+
+		assert_eq!(sparse.challenges, dense.challenges);
+		assert_eq!(sparse.eval, dense.eval);
+		assert_eq!(sparse_transcript.finalize(), dense_transcript.finalize());
+	}
+
+	#[test]
+	fn sparse_rounds_match_the_dense_prover() {
+		// Both packing widths the prover is instantiated at: the m4 prover drives phase 1 with
+		// scalars, the single-instance prover with a packed field.
+		assert_sparse_matches_dense::<F>(&overlapping_shift_system(), 0);
+		assert_sparse_matches_dense::<PackedBinaryGhash2x128b>(&overlapping_shift_system(), 1);
+	}
+
+	/// A constraint system that constrains nothing names no shift, so `g` stores no row at all.
+	///
+	/// The sparse rounds then have nothing to scan, which must still leave the transcript the one
+	/// a dense prover over the zero `g` would have written.
+	#[test]
+	fn sparse_rounds_match_the_dense_prover_with_an_empty_g() {
+		let cs = ConstraintSystem {
+			constants: vec![Word::ZERO; 4],
+			n_inout: 0,
+			n_private: 4,
+			zero_constraints: Vec::new(),
+			and_constraints: Vec::new(),
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		};
+
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		assert!(key_collection.public.dense_shift_enc.is_empty());
+		assert!(key_collection.hidden.dense_shift_enc.is_empty());
+
+		assert_sparse_matches_dense::<PackedBinaryGhash2x128b>(&cs, 2);
+	}
 }


### PR DESCRIPTION
Closes [BINIUS-460](https://linear.app/jimpo/issue/BINIUS-460/shift-sparse-sumcheck-over-the-shift-variant-and-amount-variables).

Prover-side only; the verifier is untouched and the transcript is byte-identical.

> **Revised twice.** It first hand-rolled the sparse rounds, then routed `g` through `SparseDenseProductSumcheckProver` (#2105), and now has the `Phase1SumcheckProver` @jimpo asked for. **The two performance comments above measure designs that no longer exist — disregard them**; current numbers are in the newest comment.

## What

The phase-1 sumcheck binds 15 variables: the high 9 index the `(shift variant, shift amount)` row, the low 6 the bit position within it. A constraint system names only a few dozen of the 512 rows — 16 for SHA256, 40 for Keccak — so `g` is zero almost everywhere over the row axis. But *within* a named row it is dense: every bit position carries a value. Its sparsity is in long strides, not scattered points.

`Phase1SumcheckProver` changes strategy halfway to match that:

- **The 9 row rounds** read the stored rows alone, so their cost follows the shifts the system names rather than the 512 the space holds. `h` stays dense across them and folds as any multilinear does, which is what keeps this simple — a round reads `h` at whichever row a live `g` row pairs with, so nothing has to work out in advance which rows of `h` a later round will reach.
- **The 6 bit rounds** run on the shared `bivariate_product_prover`. By then both multilinears are one dense row and there is no sparsity left to exploit.

It is an adaptation of `SparseDenseProductSumcheckProver` and inherits its central simplification: both sampled evaluations and the fold are **linear in `g`**, so a stored row contributes on its own. Rows are never paired across the split or merged, and the list stays a flat run of the same length for the whole protocol.

That linearity pays off twice more. The two key segments' rows simply **concatenate** — rows at a repeated index add up wherever `g` is read — so the merge step is gone, and with it the `2^15` buffer each segment used to be scattered into and the loop that summed the two.

## Correctness

Both provers sum the same product over the same hypercube, so field arithmetic being exact, every round message must agree exactly. Three tests, covering different things — each checked by mutation rather than assumed:

- `sparse_rounds_match_the_dense_prover` (and an empty-`g` variant) asserts a **byte-identical transcript**, the same challenges and the same reduced evaluation against a dense `bivariate_product_prover`. Verified non-vacuous by dropping the `index & half` guard on `y_1`, which made it fail.
- `from_segments_concatenates_the_two_encodings` pins the concatenation and that a repeated index adds up where `g` is read.
- `tests/shift.rs::test_shift_prove_and_verify` covers the whole reduction end to end against the real verifier, which builds `h` independently.

`cargo test --workspace` (56 suites), `cargo clippy --all --tests --benches --examples -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps` and `cargo +nightly-2026-07-01 fmt --check` are clean.

`m4-prover` and the `shift_reduction` bench are ported alongside, since the signatures change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)