### PR TITLE
BINIUS-430: verify SHA-256 binary Merkle openings in-circuit

### DIFF
--- a/crates/recursion/Cargo.toml
+++ b/crates/recursion/Cargo.toml
@@ -20,6 +20,7 @@ binius-utils = { path = "../utils" }
 digest.workspace = true
 
 [dev-dependencies]
+binius-iop-prover = { path = "../iop-prover" }
 binius-prover = { path = "../prover" }
 binius-verifier = { path = "../verifier" }
 proptest.workspace = true

--- a/crates/recursion/src/lib.rs
+++ b/crates/recursion/src/lib.rs
@@ -40,12 +40,15 @@
 //!
 //! The gadget for the first of those bullets now exists in [`challenger`], reproducing the native
 //! challenger's byte stream over wires.
-//! Driving it from `sample` and `sample_bits` is what removes that bullet.
+//! The gadgets for the second exist in [`merkle`], matching the native binary Merkle scheme.
+//! Driving them from `sample`, `sample_bits`, `recv_openings` and `recv_committed_vector` is what
+//! removes those two bullets.
 
 pub mod challenger;
 mod channel;
 mod filler;
 mod hints;
+pub mod merkle;
 mod shared;
 pub mod symbolic;
 

--- a/crates/recursion/src/merkle.rs
+++ b/crates/recursion/src/merkle.rs
@@ -1,0 +1,606 @@
+// Copyright 2026 The Binius Developers
+
+//! In-circuit verification of a binary Merkle commitment over 128-bit field elements.
+//!
+//! A recursive circuit re-checks the openings a native prover produced.
+//! So these gadgets reproduce the committing scheme's hash rules exactly.
+//!
+//! - A leaf is hashed with a full padded SHA-256 over its elements, sixteen bytes each.
+//! - An inner node is one raw block compression over the 64 bytes of its two child digests.
+//! - That compression starts from a domain-separating state, not SHA-256's own.
+//!
+//! # Element convention
+//!
+//! An element rides on two wires, low half first.
+//! The low wire carries its serialized bytes 0 to 7 and the high wire its bytes 8 to 15.
+//! Each half is read little-endian, so the pair is the element's 128-bit value split in two.
+//!
+//! # Digest convention
+//!
+//! A digest rides on four wires, in the form a block compression consumes.
+//! Wire `j` carries the two big-endian message words covering digest bytes `8j` to `8j + 8`:
+//!
+//! ```text
+//!     bits  0..32 :  big-endian u32 of digest bytes 8j     .. 8j + 4
+//!     bits 32..64 :  big-endian u32 of digest bytes 8j + 4 .. 8j + 8
+//! ```
+//!
+//! Two properties make this the cheap choice, and both explain the unusual byte order.
+//!
+//! - A node's 64-byte message block is then pure rewiring off its children's wires.
+//! - A leaf digest lands in it for free, since SHA-256 emits its state big-endian.
+//!
+//! Only an inner node's output needs a conversion.
+//! The native compression serializes its state *little*-endian, so each output word reverses.
+//!
+//! Two helpers here turn a digest or an element into the wire values a witness must carry.
+//!
+//! # Cost
+//!
+//! Counts below are AND and BMUL constraints as the frontend compiles them.
+//! Every one is pinned by this module's tests.
+//!
+//! One single-lane block compression is 726 AND constraints.
+//! A gate costs one constraint whatever its width, so two compressions can share one core.
+//! Running them as the two 32-bit lanes of that core brings each to about 380.
+//! Both places that hash independent values take this route:
+//!
+//! - folding a layer of digests up to the root above it
+//! - hashing the leaves of a whole committed vector
+//!
+//! | what is measured                        | AND          | BMUL          |
+//! | --------------------------------------- | ------------ | ------------- |
+//! | a one-element leaf digest               | 697          | 0             |
+//! | a sixteen-element leaf digest           | 2279         | 0             |
+//! | two one-element leaves sharing a core   | 707 per pair | 0             |
+//! | one inner node on its own core          | 742          | 0             |
+//! | one inner node sharing a core           | 380 per node | 0             |
+//! | one node of a verified layer's fold     | 380 per node | 0             |
+//! | one climbed level of an opening         | 738          | 8             |
+//! | picking the layer entry of an opening   | 0            | 4 * (2^L - 1) |
+//!
+//! Write `D` for the tree depth and `L` for the depth of the layer an opening climbs to.
+//! One opening therefore costs
+//!
+//! ```text
+//!     AND  = leaf digest + 738 * (D - L)
+//!     BMUL = 8 * (D - L) + 4 * (2^L - 1)
+//! ```
+//!
+//! and the layer it lands on costs `380 * (2^L - 1)` AND once, shared by every query.
+//!
+//! ## Choosing the layer depth
+//!
+//! Raising `L` by one level changes the bill per query, out of `n_q` queries, by
+//!
+//! ```text
+//!     AND  :  -738 + 380 * 2^L / n_q
+//!     BMUL :  +4 * 2^L - 8
+//! ```
+//!
+//! The two columns behave nothing alike.
+//!
+//! - The AND column breaks even at `2^L = 1.94 * n_q`, one level above the native rule.
+//! - That native rule sets the layer depth to `ceil(log2(n_q))`.
+//! - The BMUL column gains nothing past `L = 1`, since the entry selector grows with the layer.
+//! - The climb it shortens gives back only eight selects a level, which never covers that.
+//!
+//! AND and BMUL fill separate constraint columns, so there is no one budget to minimise.
+//! At `D = 20`, `n_q = 100` and one-element leaves, charging a BMUL like an AND:
+//!
+//! ```text
+//!     L = 6 :  11280 AND + 364 BMUL
+//!     L = 7 :  10782 AND + 612 BMUL
+//!     L = 8 :  10526 AND + 1116 BMUL
+//! ```
+//!
+//! AND leads BMUL by more than an order of magnitude, so the AND column decides.
+//!
+//! - On AND alone the cheapest choice is `L = 8`.
+//! - Charging BMUL at the same rate moves it to `L = 7`.
+//! - Neither is a constant, since both track `log2(n_q)`.
+//! - A different query count means re-running the arithmetic above.
+//! - Which column is scarce depends on what the rest of the circuit put in each one.
+//!
+//! One lever is still open.
+//! A climb is sequential, so an opening cannot share cores with itself.
+//! Two openings can, since the queries are independent.
+//!
+//! Verifying a pair of them in shared cores costs about 380 AND per level per query.
+//! That halves what raising `L` saves, so the AND-optimal `L` drops by roughly one level.
+
+use std::array;
+
+use binius_circuits::{
+	bytes::swap_bytes_32,
+	multiplexer::multi_wire_multiplex,
+	sha256::{State, sha256_compress, sha256_compress_2x, sha256_fixed},
+	util::clear_high_bits,
+};
+use binius_core::Word;
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+
+#[cfg(test)]
+mod tests;
+
+/// Wires carrying one SHA-256 digest.
+pub const DIGEST_WORDS: usize = 4;
+
+/// Wires carrying one field element.
+pub const ELEMENT_WORDS: usize = 2;
+
+/// Bytes one field element serializes to.
+const ELEMENT_BYTES: usize = 16;
+
+/// 32-bit words in one SHA-256 digest, which is also half a message block.
+const DIGEST_HALF_WORDS: usize = 8;
+
+/// Initial state a pair of child digests is folded from.
+///
+/// The scheme replaces SHA-256's own initial state with `SHA-256("BINIUS SHA-256 COMPRESS")`,
+/// read as eight little-endian words.
+/// Domain-separating the two-to-one compression this way keeps a node digest from ever
+/// coinciding with a plain SHA-256 hash of the same 64 bytes.
+pub const COMPRESSION_IV: [u32; 8] = [
+	0x16684ff5, 0x53a717d2, 0x1d4154c8, 0x574f1b56, 0xa37e524e, 0xf12dfd41, 0x6303f932, 0x3754018c,
+];
+
+/// A SHA-256 digest in circuit form, in the byte order the [module docs](self) describe.
+pub type Digest = [Wire; DIGEST_WORDS];
+
+/// One field element in circuit form, as its low 64 bits then its high 64 bits.
+pub type Element = [Wire; ELEMENT_WORDS];
+
+/// The wire values a [`Digest`] carries for a given 32-byte digest.
+pub fn digest_words(bytes: &[u8; 32]) -> [u64; DIGEST_WORDS] {
+	// A message word is four digest bytes read big-endian, the order a compression consumes.
+	let word = |offset: usize| {
+		u32::from_be_bytes(
+			bytes[offset..offset + 4]
+				.try_into()
+				.expect("the slice spans exactly four bytes"),
+		) as u64
+	};
+	// Two consecutive message words share a wire, the earlier one in the low half.
+	array::from_fn(|j| word(8 * j) | (word(8 * j + 4) << 32))
+}
+
+/// Writes a 32-byte digest into the wires that carry it.
+pub fn populate_digest(w: &mut WitnessFiller, digest: &Digest, bytes: &[u8; 32]) {
+	// One wire per eight digest bytes, in the packed order the digest convention fixes.
+	for (wire, value) in digest.iter().zip(digest_words(bytes)) {
+		w[*wire] = Word(value);
+	}
+}
+
+/// The wire values an [`Element`] carries for a given field element.
+///
+/// The argument is the element's sixteen-byte little-endian serialization read as one integer.
+pub const fn element_words(value: u128) -> [u64; ELEMENT_WORDS] {
+	// Serialized bytes 0 to 7 in the low wire, bytes 8 to 15 in the high wire.
+	[value as u64, (value >> 64) as u64]
+}
+
+/// Writes a field element into the wires that carry it.
+pub fn populate_element(w: &mut WitnessFiller, element: &Element, value: u128) {
+	// Two wires per element, low serialized half first.
+	for (wire, word) in element.iter().zip(element_words(value)) {
+		w[*wire] = Word(word);
+	}
+}
+
+/// Verifies that a slice of digests is one Merkle layer beneath a claimed root.
+///
+/// The digests are folded pairwise until one is left, which must equal the claimed root.
+/// The fold takes one round per level, so a layer only passes at the depth its width claims.
+///
+/// # Panics
+///
+/// Panics unless the number of layer digests is a non-zero power of two.
+pub fn verify_layer(builder: &CircuitBuilder, root: Digest, layer_digests: &[Digest]) {
+	assert!(
+		layer_digests.len().is_power_of_two(),
+		"precondition: the number of layer digests must be a non-zero power of two"
+	);
+
+	// Naming the gates makes a failing assertion point back at this gadget.
+	let builder = builder.subcircuit("verify_layer");
+	// Rebuild every node above the layer, up to the single digest at the top.
+	let folded = fold_to_root(&builder, layer_digests);
+	// Equality with the claimed root is the whole check.
+	builder.assert_eq_v("root", folded, root);
+}
+
+/// Verifies a whole committed vector against a claimed root, by rebuilding the tree over it.
+///
+/// The values arrive in leaf order, with a fixed number of them under each leaf.
+///
+/// # Panics
+///
+/// Panics unless all of the following hold.
+///
+/// - The number of values under one leaf is non-zero.
+/// - It divides the total number of values.
+/// - The resulting leaf count is a power of two.
+pub fn verify_vector(builder: &CircuitBuilder, root: Digest, data: &[Element], batch_size: usize) {
+	assert_ne!(batch_size, 0, "precondition: batch_size must be non-zero");
+	assert!(
+		data.len().is_multiple_of(batch_size),
+		"precondition: data length must be a multiple of batch_size"
+	);
+	let n_leaves = data.len() / batch_size;
+	assert!(
+		n_leaves.is_power_of_two(),
+		"precondition: data.len() / batch_size must be a non-zero power of two"
+	);
+
+	let builder = builder.subcircuit("verify_vector");
+	// The values under one leaf, a contiguous run of the committed data.
+	let leaf = |i: usize| &data[i * batch_size..(i + 1) * batch_size];
+
+	// Leaves are independent, so hash them two at a time in the two lanes of one compression chain.
+	let mut digests = Vec::with_capacity(n_leaves);
+	let mut i = 0;
+	while i + 1 < n_leaves {
+		let b = builder.subcircuit(format!("leaf[{i}..{}]", i + 2));
+		digests.extend(leaf_digest_2x(&b, [leaf(i), leaf(i + 1)]));
+		i += 2;
+	}
+	// The leaf count is a power of two, so only a single-leaf tree leaves one unpaired.
+	if i < n_leaves {
+		digests.push(leaf_digest(&builder.subcircuit(format!("leaf[{i}]")), leaf(i)));
+	}
+
+	// Folding the leaf digests rebuilds every inner node, so the top digest covers all the data.
+	let folded = fold_to_root(&builder, &digests);
+	// It must be the root that was committed to.
+	builder.assert_eq_v("root", folded, root);
+}
+
+/// Verifies one Merkle opening against an already-verified layer of digests.
+///
+/// The gadget hashes the opened leaf, then climbs one level per authentication-path sibling:
+///
+/// ```text
+///     level k:  (running digest, sibling k)  ->  running digest at level k + 1
+/// ```
+///
+/// Bit `k` of the index says which side the running digest sits on at level `k`.
+///
+/// - Clear puts it on the left, so that level's sibling is the right child.
+/// - Set puts it on the right, so that level's sibling is the left child.
+///
+/// The digest the climb arrives at must equal the layer entry the remaining index bits address.
+/// That is what ties the opened leaf to the root the layer was verified against.
+///
+/// # Why the index is a wire
+///
+/// A caller may derive the query index in-circuit, so it cannot be a build-time constant.
+/// Reading it from a wire has one consequence worth stating.
+///
+/// - Only the low index bits spanning the tree depth are read.
+/// - So the opening is verified at the index reduced modulo the number of leaves.
+/// - A caller whose index may fall out of range must constrain it separately.
+///
+/// # Panics
+///
+/// Panics unless all of the following hold.
+///
+/// - The layer depth is at most the tree depth.
+/// - The tree depth is below the wire width.
+/// - The layer holds one digest per node at its own depth.
+/// - The authentication path holds one sibling per level between the two depths.
+pub fn verify_opening(
+	builder: &CircuitBuilder,
+	index: Wire,
+	values: &[Element],
+	layer_depth: usize,
+	tree_depth: usize,
+	layer_digests: &[Digest],
+	branch: &[Digest],
+) {
+	assert!(layer_depth <= tree_depth, "precondition: layer_depth must be at most tree_depth");
+	assert!(tree_depth < Word::BITS, "precondition: tree_depth must be below the wire width");
+	assert_eq!(
+		layer_digests.len(),
+		1 << layer_depth,
+		"precondition: layer_digests must have 2^layer_depth entries"
+	);
+	assert_eq!(
+		branch.len(),
+		tree_depth - layer_depth,
+		"precondition: branch must have tree_depth - layer_depth siblings"
+	);
+
+	let builder = builder.subcircuit("verify_opening");
+
+	// Bottom of the authentication path: the digest of the leaf the opening claims.
+	let mut digest = leaf_digest(&builder.subcircuit("leaf"), values);
+
+	for (level, sibling) in branch.iter().enumerate() {
+		let b = builder.subcircuit(format!("climb[{level}]"));
+
+		// A select gate reads bit 63 alone, so lift this level's index bit up to it.
+		let on_right = b.shl(index, (Word::BITS - 1 - level) as u32);
+		// Order the pair by that bit, putting the running digest on the side it names.
+		let left = array::from_fn(|j| b.select(on_right, sibling[j], digest[j]));
+		let right = array::from_fn(|j| b.select(on_right, digest[j], sibling[j]));
+
+		// One node hash carries the running digest up a level.
+		digest = compress_node(&b, left, right);
+	}
+
+	// The climb consumed one index bit per level, so the bits above them address the layer.
+	let layer_index = builder.shr(index, (tree_depth - layer_depth) as u32);
+	// The multiplexer reads its candidates as slices, one per layer entry.
+	let entries = layer_digests.iter().map(|d| &d[..]).collect::<Vec<_>>();
+	let selected = multi_wire_multiplex(&builder, &entries, layer_index);
+	// Matching the entry there binds the leaf to the layer, hence to the root above it.
+	builder.assert_eq_v(
+		"layer_digest",
+		digest,
+		selected
+			.try_into()
+			.expect("the multiplexer returns one wire per digest wire"),
+	);
+}
+
+/// The digest of one leaf: SHA-256 over its elements, sixteen little-endian bytes each.
+///
+/// # Panics
+///
+/// Panics if the leaf holds no elements.
+pub fn leaf_digest(builder: &CircuitBuilder, values: &[Element]) -> Digest {
+	assert!(!values.is_empty(), "precondition: a leaf must hold at least one element");
+
+	// The leaf's serialization, as the big-endian message words a compression consumes.
+	let words = leaf_message_words(builder, values);
+	// The byte length is known while the circuit is built, so the padding is all constants.
+	let state = sha256_fixed(builder, &words, values.len() * ELEMENT_BYTES);
+
+	// SHA-256 serializes its state big-endian, which is already the message-word view.
+	pack_words(builder, &state)
+}
+
+/// One inner Merkle node: the scheme's compression over its two child digests concatenated.
+pub fn compress_node(builder: &CircuitBuilder, left: Digest, right: Digest) -> Digest {
+	// Left child then right child is 64 bytes, which is exactly one message block.
+	let block = node_block(builder, left, right);
+	// A raw compression from the domain-separating state, with no padding and no length field.
+	let out = sha256_compress(builder, compression_iv(builder), block);
+
+	// A node digest is the final state serialized little-endian, one word at a time.
+	// So its big-endian message-word view is each state word byte-reversed.
+	pack_words(builder, &out.0).map(|w| swap_bytes_32(builder, w))
+}
+
+/// Two inner Merkle nodes at once, as the two 32-bit lanes of a single compression.
+///
+/// Nodes at the same level are independent, and a gate costs one constraint whatever its width.
+/// So a pair of nodes costs about what one node costs.
+fn compress_node_2x(builder: &CircuitBuilder, nodes: [(Digest, Digest); 2]) -> [Digest; 2] {
+	// One message block per node, each still a single-lane value in its low 32 bits.
+	let block_0 = node_block(builder, nodes[0].0, nodes[0].1);
+	let block_1 = node_block(builder, nodes[1].0, nodes[1].1);
+
+	// Lane 0 in the low half of every wire, lane 1 in the high half.
+	// The two halves are disjoint, so XOR is what merges them.
+	let merged = array::from_fn(|k| builder.bxor(block_0[k], builder.shl(block_1[k], 32)));
+	// Both lanes fold from the same state, so its words are replicated into both halves.
+	let iv = replicate_lanes(builder, compression_iv(builder));
+	let out = sha256_compress_2x(builder, iv, merged);
+
+	// Split the lanes apart, then byte-reverse each word as the single-lane path does.
+	[Lane::Low, Lane::High]
+		.map(|lane| pack_lane(builder, &out.0, lane).map(|w| swap_bytes_32(builder, w)))
+}
+
+/// Folds a power-of-two layer of digests down to the single digest above them all.
+///
+/// Each round pairs neighbours and replaces them with their parent, halving the layer:
+///
+/// ```text
+///     [d_0, d_1, ..., d_{n-1}]  ->  [node(d_0, d_1), ..., node(d_{n-2}, d_{n-1})]
+/// ```
+///
+/// # Panics
+///
+/// Panics unless the number of digests is a non-zero power of two.
+fn fold_to_root(builder: &CircuitBuilder, digests: &[Digest]) -> Digest {
+	assert!(
+		digests.len().is_power_of_two(),
+		"precondition: the number of digests must be a non-zero power of two"
+	);
+
+	let mut layer = digests.to_vec();
+	let mut level = 0;
+	// Each round climbs one level, so this runs the base-two logarithm of the layer width.
+	while layer.len() > 1 {
+		let b = builder.subcircuit(format!("fold[{level}]"));
+		let mut parents = Vec::with_capacity(layer.len() / 2);
+
+		// Four digests give two independent parents, which share one two-lane compression.
+		let mut quads = layer.chunks_exact(4);
+		for quad in &mut quads {
+			parents.extend(compress_node_2x(&b, [(quad[0], quad[1]), (quad[2], quad[3])]));
+		}
+		// A layer of exactly two digests has one parent, with no partner to share a core with.
+		if let [left, right] = *quads.remainder() {
+			parents.push(compress_node(&b, left, right));
+		}
+
+		// The parents become the next round's layer, half as wide.
+		layer = parents;
+		level += 1;
+	}
+
+	// One digest is left, the root above the layer that came in.
+	layer[0]
+}
+
+/// The digests of two equal-size leaves, as the two 32-bit lanes of one compression chain.
+///
+/// Both leaves serialize to the same byte length.
+/// So their padded messages hold the same number of blocks and the two lanes advance in step.
+///
+/// # Why no hint is needed
+///
+/// Blocks within one leaf chain, so splitting those across lanes would need a hint to decouple.
+/// Nothing crosses between these two lanes, since the leaves are separate messages.
+///
+/// # Panics
+///
+/// Panics unless both leaves are non-empty and hold the same number of elements.
+fn leaf_digest_2x(builder: &CircuitBuilder, values: [&[Element]; 2]) -> [Digest; 2] {
+	assert!(!values[0].is_empty(), "precondition: a leaf must hold at least one element");
+	assert_eq!(
+		values[0].len(),
+		values[1].len(),
+		"precondition: both leaves must hold the same number of elements"
+	);
+
+	// Serialize and pad each leaf on its own: equal lengths in, equal block counts out.
+	let padded = values.map(|v| padded_leaf_words(builder, &leaf_message_words(builder, v)));
+	// Both lanes open from SHA-256's initial state, replicated into both halves.
+	let mut state = replicate_lanes(builder, State::iv(builder));
+	// Sixteen message words to a block, and the two lanes consume their blocks in lockstep.
+	for (i, (block_0, block_1)) in padded[0]
+		.chunks_exact(16)
+		.zip(padded[1].chunks_exact(16))
+		.enumerate()
+	{
+		let b = builder.subcircuit(format!("compress[{i}]"));
+		// Lane 0 low, lane 1 high, merged by XOR since the halves are disjoint.
+		let merged = array::from_fn(|k| b.bxor(block_0[k], b.shl(block_1[k], 32)));
+		state = sha256_compress_2x(&b, state, merged);
+	}
+
+	// SHA-256 serializes its state big-endian, so no byte reversal is due here.
+	[Lane::Low, Lane::High].map(|lane| pack_lane(builder, &state.0, lane))
+}
+
+/// Which 32-bit half of a two-lane wire a word is read from.
+#[derive(Clone, Copy)]
+enum Lane {
+	/// Bits `0..32`.
+	Low,
+	/// Bits `32..64`.
+	High,
+}
+
+/// Packs eight single-lane 32-bit words, pairwise, into the four wires of a [`Digest`].
+///
+/// Word `2j` lands in the low half of wire `j` and word `2j + 1` in the high half.
+///
+/// It is a precondition that every word's high half is already empty.
+fn pack_words(builder: &CircuitBuilder, words: &[Wire; DIGEST_HALF_WORDS]) -> Digest {
+	// The high half is empty by precondition, so the upper word shifts in without a collision.
+	array::from_fn(|j| builder.bxor(words[2 * j], builder.shl(words[2 * j + 1], 32)))
+}
+
+/// Packs one lane of eight two-lane words, pairwise, into the four wires of a [`Digest`].
+fn pack_lane(builder: &CircuitBuilder, words: &[Wire; DIGEST_HALF_WORDS], lane: Lane) -> Digest {
+	// Two words per output wire, each carrying the other lane's word in its opposite half.
+	array::from_fn(|j| {
+		let (lo, hi) = (words[2 * j], words[2 * j + 1]);
+		match lane {
+			// The low word must be isolated, since the word above it is XORed on top.
+			// The upper word needs no masking: shifting it up drops the lane below it.
+			Lane::Low => builder.bxor(clear_high_bits(builder, lo, 32), builder.shl(hi, 32)),
+			// Shifting down isolates the low word; shifting back up drops what sat beneath it.
+			Lane::High => builder.bxor(builder.shr(lo, 32), builder.shl(builder.shr(hi, 32), 32)),
+		}
+	})
+}
+
+/// The eight big-endian message words a [`Digest`] contributes to a block, in block order.
+fn digest_message_words(builder: &CircuitBuilder, digest: Digest) -> [Wire; DIGEST_HALF_WORDS] {
+	array::from_fn(|k| {
+		// Two message words share a wire, so the word index halves to a wire index.
+		let packed = digest[k / 2];
+		if k.is_multiple_of(2) {
+			// Even words sit in the low half, which needs isolating from the word above it.
+			clear_high_bits(builder, packed, 32)
+		} else {
+			// Odd words sit in the high half, so shifting down both isolates and places them.
+			builder.shr(packed, 32)
+		}
+	})
+}
+
+/// The 64-byte message block of an inner node: the left child's digest, then the right child's.
+fn node_block(builder: &CircuitBuilder, left: Digest, right: Digest) -> [Wire; 16] {
+	// Eight message words per digest, so unpacking the children covers the whole block.
+	let left = digest_message_words(builder, left);
+	let right = digest_message_words(builder, right);
+	// The left child fills the block's first half and the right child its second.
+	array::from_fn(|k| {
+		if k < DIGEST_HALF_WORDS {
+			left[k]
+		} else {
+			right[k - DIGEST_HALF_WORDS]
+		}
+	})
+}
+
+/// The domain-separating initial state as a compression input, one 32-bit word per wire.
+fn compression_iv(builder: &CircuitBuilder) -> State {
+	// The state is fixed by the scheme, so it enters as constants and costs no constraints.
+	State::new(array::from_fn(|i| builder.add_constant(Word(COMPRESSION_IV[i] as u64))))
+}
+
+/// Replicates each state word into both 32-bit lanes of its wire.
+///
+/// A two-lane compression starts both lanes from the same state.
+fn replicate_lanes(builder: &CircuitBuilder, state: State) -> State {
+	// The incoming high half is empty, so a copy shifted up sits beside the original.
+	State::new(state.0.map(|w| builder.bxor(w, builder.shl(w, 32))))
+}
+
+/// The big-endian message words of one leaf's serialized elements, in byte order.
+fn leaf_message_words(builder: &CircuitBuilder, values: &[Element]) -> Vec<Wire> {
+	// Sixteen bytes an element and four bytes a message word, so four words an element.
+	let mut words = Vec::with_capacity(values.len() * 4);
+	for &[lo, hi] in values {
+		// The low serialized half comes first in the message, then the high half.
+		for half in [lo, hi] {
+			// The element serializes little-endian, so each group of four bytes reverses into its
+			// big-endian message word.
+			let swapped = swap_bytes_32(builder, half);
+			// The earlier four bytes now sit in the low half, the later four above them.
+			words.push(clear_high_bits(builder, swapped, 32));
+			words.push(builder.shr(swapped, 32));
+		}
+	}
+	words
+}
+
+/// Appends SHA-256's padding to a leaf's message words, filling out whole blocks.
+///
+/// A leaf is a whole number of sixteen-byte elements, so its length is a multiple of four bytes.
+/// The delimiter byte therefore always opens a fresh word.
+/// Every appended word is a build-time constant, so the padding costs no constraints.
+///
+/// # Panics
+///
+/// Panics if the message bit length does not fit in the low half of SHA-256's length field.
+fn padded_leaf_words(builder: &CircuitBuilder, message: &[Wire]) -> Vec<Wire> {
+	// Four bytes to a message word, and SHA-256's length field counts bits.
+	let len_bytes = message.len() * 4;
+	let bit_len = (len_bytes as u64) * 8;
+	assert!(bit_len <= u32::MAX as u64, "precondition: the message bit length must fit in 32 bits");
+
+	// The padding needs the delimiter byte plus the eight-byte length field.
+	// Rounding that up to whole 64-byte blocks gives sixteen words a block.
+	let n_words = (len_bytes + 9).div_ceil(64) * 16;
+
+	let mut words = Vec::with_capacity(n_words);
+	words.extend_from_slice(message);
+	// The delimiter is one set bit, at the top of the word just past the message.
+	words.push(builder.add_constant(Word(0x8000_0000)));
+	// Zero-fill up to the length field, whose high word stays zero at these lengths.
+	words.resize(n_words - 1, builder.add_constant(Word::ZERO));
+	// The last word closes the final block with the message's bit length.
+	words.push(builder.add_constant(Word(bit_len)));
+	words
+}

--- a/crates/recursion/src/merkle/tests.rs
+++ b/crates/recursion/src/merkle/tests.rs
@@ -1,0 +1,876 @@
+// Copyright 2026 The Binius Developers
+
+//! Checks of the in-circuit Merkle gadgets against the native committing scheme they mirror.
+
+use std::array;
+
+use binius_core::Word;
+use binius_field::BinaryField128bGhash as B128;
+use binius_frontend::{CircuitBuilder, CircuitStat, PopulateError, WitnessFiller};
+use binius_hash::{
+	CompressionFunction, hash_serialize,
+	sha256::{Sha256Compression, Sha256HashSuite},
+};
+use binius_iop::merkle_tree::MerkleTreeScheme;
+use binius_iop_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+use digest::Output;
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+use sha2::{Digest as _, Sha256};
+
+use super::*;
+
+/// The native committer whose trees and openings every gadget here is checked against.
+type Prover = BinaryMerkleTreeProver<B128, Sha256HashSuite>;
+
+/// The Fiat-Shamir hasher of the transcript an opening travels through.
+type Challenger = HasherChallenger<Sha256>;
+
+/// A given number of uniformly random field elements.
+fn random_values(rng: &mut StdRng, n: usize) -> Vec<B128> {
+	// Every test seeds its own generator, so a failure reproduces from the seed alone.
+	(0..n).map(|_| B128::from(rng.random::<u128>())).collect()
+}
+
+/// A hash output as the plain 32 bytes the committing scheme moves around.
+fn digest_bytes(digest: &Output<Sha256>) -> [u8; 32] {
+	// Both forms hold the same bytes, so this only drops the hasher-specific wrapper.
+	(*digest).into()
+}
+
+/// A given number of fresh witness elements.
+fn element_wires(builder: &CircuitBuilder, n: usize) -> Vec<Element> {
+	// Two wires an element: its serialized low half, then its high half.
+	(0..n)
+		.map(|_| array::from_fn(|_| builder.add_witness()))
+		.collect()
+}
+
+/// A given number of fresh witness digests.
+fn digest_wires(builder: &CircuitBuilder, n: usize) -> Vec<Digest> {
+	// Four wires a digest, each carrying two of the message words a compression consumes.
+	(0..n)
+		.map(|_| array::from_fn(|_| builder.add_witness()))
+		.collect()
+}
+
+/// Writes one field element into each element's pair of wires.
+fn fill_elements(w: &mut WitnessFiller, wires: &[Element], values: &[B128]) {
+	// A count mismatch would leave wires unwritten, which reads later as a wrong value.
+	assert_eq!(wires.len(), values.len(), "one element per value");
+	// Splitting a value across its two wires is the packing convention, not a choice here.
+	for (element, value) in wires.iter().zip(values) {
+		populate_element(w, element, u128::from(*value));
+	}
+}
+
+/// Writes one 32-byte digest into each digest's wires.
+fn fill_digests(w: &mut WitnessFiller, wires: &[Digest], bytes: &[[u8; 32]]) {
+	// As with elements, an unwritten wire would masquerade as a corrupted digest.
+	assert_eq!(wires.len(), bytes.len(), "one digest per byte string");
+	// The byte order each wire holds is fixed by the digest convention.
+	for (digest, bytes) in wires.iter().zip(bytes) {
+		populate_digest(w, digest, bytes);
+	}
+}
+
+/// Asserts every retained failure sits under the given assertion path, and that none were dropped.
+///
+/// Locating the failure is what separates "the circuit rejected this" from "the circuit rejected
+/// this for the reason under test".
+fn assert_failed_paths(error: &PopulateError, path: &str) {
+	// Witness population may retain fewer failures than it found, and a dropped one could sit
+	// anywhere else in the circuit.
+	assert_eq!(
+		error.total,
+		error.failures.len(),
+		"the failure list must be complete, so every path can be checked"
+	);
+	// A rejection that named no failing assertion would pass a negative test for free.
+	assert!(error.total > 0, "an unsatisfied circuit must report at least one failure");
+	for failure in &error.failures {
+		// Gate names are hierarchical, so a prefix match pins the failure to one gadget.
+		assert!(
+			failure.path.starts_with(path),
+			"unexpected failing assertion {:?}, expected one under {path:?}",
+			failure.path
+		);
+		// A failure with no message would leave a real regression undiagnosable.
+		assert!(!failure.detail.is_empty(), "a failure must carry a diagnostic");
+	}
+}
+
+#[test]
+fn compression_iv_is_the_domain_separator() {
+	// Invariant: the state every inner node folds from is the hash of the scheme's separator
+	// string, read as eight little-endian words.
+	//
+	// Why it is pinned: starting from the hash function's own initial state would let a node
+	// digest coincide with a plain hash of the same 64 bytes.
+	let separator: [u8; 32] = Sha256::digest(b"BINIUS SHA-256 COMPRESS").into();
+
+	// Four bytes a word, read little-endian, which is the order the native scheme reads.
+	let expected: [u32; 8] = array::from_fn(|i| {
+		u32::from_le_bytes(
+			separator[4 * i..4 * i + 4]
+				.try_into()
+				.expect("four bytes per word"),
+		)
+	});
+	assert_eq!(COMPRESSION_IV, expected);
+}
+
+#[test]
+fn element_words_split_the_serialization() {
+	// Invariant: an element's sixteen serialized bytes split across two wires, low half first.
+	//
+	// Fixture state: the bytes 0x00 through 0x0f, in serialization order.
+	//
+	//     serialized :  00 01 02 03 04 05 06 07 | 08 09 0a 0b 0c 0d 0e 0f
+	//     low wire   :  0x0706050403020100        bytes 0 to 7, little-endian
+	//     high wire  :  0x0f0e0d0c0b0a0908        bytes 8 to 15, little-endian
+	let value = 0x0f0e0d0c_0b0a0908_07060504_03020100u128;
+	assert_eq!(element_words(value), [0x07060504_03020100, 0x0f0e0d0c_0b0a0908]);
+}
+
+#[test]
+fn digest_words_carry_the_message_words() {
+	// Invariant: each digest wire holds the two big-endian message words a compression reads for
+	// eight consecutive digest bytes.
+	//
+	// Fixture state: the 32 bytes 0x00 through 0x1f, in digest order.
+	//
+	//     wire 0 low   :  bytes 00 01 02 03  ->  0x00010203
+	//     wire 0 high  :  bytes 04 05 06 07  ->  0x04050607
+	//     wire 3 low   :  bytes 18 19 1a 1b  ->  0x18191a1b
+	//     wire 3 high  :  bytes 1c 1d 1e 1f  ->  0x1c1d1e1f
+	let bytes: [u8; 32] = array::from_fn(|i| i as u8);
+	let words = digest_words(&bytes);
+	// The first and last wires bracket the packing, so a swapped half or byte order shows here.
+	assert_eq!(words[0], 0x04050607_00010203);
+	assert_eq!(words[3], 0x1c1d1e1f_18191a1b);
+}
+
+/// Checks the in-circuit hash of one leaf against the native scheme's hash of the same elements.
+///
+/// The comparison lives inside the circuit, as an equality assertion against a public claim.
+/// So a mismatch fails witness population rather than a comparison made in Rust.
+fn check_leaf_digest(values: &[B128]) {
+	// Reference value: what the native scheme hashes these elements to.
+	let expected = digest_bytes(&hash_serialize::<B128, Sha256>(values).expect("B128 serializes"));
+
+	let builder = CircuitBuilder::new();
+	// The leaf's elements are witness data, as a decommitted leaf would be.
+	let wires = element_wires(&builder, values.len());
+	// The native digest enters on public wires, so the assertion spans circuit against native.
+	let claimed: Digest = array::from_fn(|_| builder.add_inout());
+	builder.assert_eq_v("leaf", leaf_digest(&builder, &wires), claimed);
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	// Only the inputs and the reference value are written; the digest wires are derived.
+	fill_elements(&mut w, &wires, values);
+	populate_digest(&mut w, &claimed, &expected);
+
+	// Population evaluates every gate and assertion, so a wrong digest fails right here.
+	circuit
+		.populate_wire_witness(&mut w)
+		.expect("the circuit must reproduce the native leaf digest");
+	// Verification re-checks that same witness against the constraint system itself.
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("every constraint must hold");
+}
+
+#[test]
+fn leaf_digest_matches_hash_serialize() {
+	let mut rng = StdRng::seed_from_u64(0);
+
+	// Invariant: the in-circuit leaf hash agrees with the native one at every leaf width.
+	//
+	// Fixture state: an element serializes to 16 bytes and a hash block is 64 bytes, so the
+	// widths below straddle the block boundary in both directions.
+	//
+	//     1, 2 elements   :  16 and 32 bytes, the narrowest leaves
+	//     3, 5 elements   :  48 and 80 bytes, so the padding lands mid-block
+	//     4, 8, 16        :  64, 128 and 256 bytes, so the message fills whole blocks
+	for leaf_size in [1, 2, 3, 4, 5, 8, 16] {
+		check_leaf_digest(&random_values(&mut rng, leaf_size));
+	}
+}
+
+#[test]
+fn leaf_digest_2x_matches_hash_serialize() {
+	let mut rng = StdRng::seed_from_u64(1);
+
+	// Invariant: hashing two equal-width leaves in the two 32-bit lanes of one compression chain
+	// gives each lane the digest that leaf would get on its own.
+	//
+	// Fixture state: widths of 1, 3, 4 and 16 elements, covering mid-block and block-aligned
+	// padding at both the narrowest and a multi-block width.
+	for leaf_size in [1, 3, 4, 16] {
+		// Independent random leaves, so a value leaking between lanes cannot go unnoticed.
+		let values = [
+			random_values(&mut rng, leaf_size),
+			random_values(&mut rng, leaf_size),
+		];
+		// Reference values: each leaf hashed natively on its own, with no notion of lanes.
+		let expected = values.each_ref().map(|values| {
+			digest_bytes(&hash_serialize::<B128, Sha256>(values).expect("B128 serializes"))
+		});
+
+		let builder = CircuitBuilder::new();
+		// Equal widths in, so both padded messages hold the same number of blocks.
+		let wires = [
+			element_wires(&builder, leaf_size),
+			element_wires(&builder, leaf_size),
+		];
+		// One public claim per lane, each carrying that lane's native digest.
+		let claimed: [Digest; 2] = array::from_fn(|_| array::from_fn(|_| builder.add_inout()));
+		let computed = leaf_digest_2x(&builder, [&wires[0], &wires[1]]);
+		// Pinning the lanes separately is what rules out a swapped or duplicated lane.
+		for lane in 0..2 {
+			builder.assert_eq_v(format!("leaf[{lane}]"), computed[lane], claimed[lane]);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		// Both leaves' elements and both reference digests, the only hand-written wires.
+		for lane in 0..2 {
+			fill_elements(&mut w, &wires[lane], &values[lane]);
+			populate_digest(&mut w, &claimed[lane], &expected[lane]);
+		}
+
+		// A lane that drifted from its own message fails one of the two assertions here.
+		circuit
+			.populate_wire_witness(&mut w)
+			.expect("both lanes must reproduce their native leaf digest");
+		circuit
+			.constraint_system()
+			.verify(&w.into_value_vec())
+			.expect("every constraint must hold");
+	}
+}
+
+#[test]
+fn compress_node_matches_sha256_compression() {
+	let mut rng = StdRng::seed_from_u64(2);
+
+	// Invariant: an in-circuit inner node equals the native two-to-one compression of the same
+	// pair of child digests.
+	//
+	// Fixture state: four random child pairs, each pair being the 64 bytes of one message block.
+	for _ in 0..4 {
+		// A node hash never inspects what its children hash, so random bytes are enough.
+		let children: [[u8; 32]; 2] = array::from_fn(|_| array::from_fn(|_| rng.random()));
+		// Reference value: the native compression over the two children concatenated.
+		let expected = digest_bytes(
+			&Sha256Compression::default().compress([children[0].into(), children[1].into()]),
+		);
+
+		let builder = CircuitBuilder::new();
+		// Both children are witness data, as an authentication path supplies them.
+		let inputs = digest_wires(&builder, 2);
+		let claimed: Digest = array::from_fn(|_| builder.add_inout());
+		// Left child first, which is the order the message block lays them out in.
+		builder.assert_eq_v("node", compress_node(&builder, inputs[0], inputs[1]), claimed);
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		fill_digests(&mut w, &inputs, &children);
+		populate_digest(&mut w, &claimed, &expected);
+
+		// A wrong byte order anywhere in the block or the output fails here.
+		circuit
+			.populate_wire_witness(&mut w)
+			.expect("the circuit must reproduce the native node digest");
+		circuit
+			.constraint_system()
+			.verify(&w.into_value_vec())
+			.expect("every constraint must hold");
+	}
+}
+
+#[test]
+fn compress_node_2x_matches_sha256_compression() {
+	let mut rng = StdRng::seed_from_u64(3);
+
+	// Invariant: two inner nodes folded in the two lanes of one compression each equal the native
+	// compression of their own children.
+	//
+	// Fixture state: four independent children, paired into two nodes, one per lane.
+	//
+	//     lane 0 :  node(child 0, child 1)
+	//     lane 1 :  node(child 2, child 3)
+	let children: [[u8; 32]; 4] = array::from_fn(|_| array::from_fn(|_| rng.random()));
+	// Reference values: each node compressed natively, with no notion of lanes.
+	let expected: [[u8; 32]; 2] = array::from_fn(|i| {
+		digest_bytes(
+			&Sha256Compression::default()
+				.compress([children[2 * i].into(), children[2 * i + 1].into()]),
+		)
+	});
+
+	let builder = CircuitBuilder::new();
+	let inputs = digest_wires(&builder, 4);
+	// One public claim per lane, so neither lane can borrow the other's answer.
+	let claimed: [Digest; 2] = array::from_fn(|_| array::from_fn(|_| builder.add_inout()));
+	let computed = compress_node_2x(&builder, [(inputs[0], inputs[1]), (inputs[2], inputs[3])]);
+	for lane in 0..2 {
+		builder.assert_eq_v(format!("node[{lane}]"), computed[lane], claimed[lane]);
+	}
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	fill_digests(&mut w, &inputs, &children);
+	for lane in 0..2 {
+		populate_digest(&mut w, &claimed[lane], &expected[lane]);
+	}
+
+	// Merging the lanes and splitting them apart again must be lossless, or this fails.
+	circuit
+		.populate_wire_witness(&mut w)
+		.expect("both lanes must reproduce their native node digest");
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("every constraint must hold");
+}
+
+/// Builds a circuit that folds a layer of digests to a claimed root, and reports the outcome.
+///
+/// Filling the witness is what runs the check.
+/// So a layer that cannot reach the root surfaces as an error here rather than a panic.
+fn run_layer(root: &[u8; 32], layer: &[[u8; 32]]) -> Result<(), PopulateError> {
+	let builder = CircuitBuilder::new();
+	// The root is public, since it is what the commitment pinned down.
+	let root_wires: Digest = array::from_fn(|_| builder.add_inout());
+	// The layer is witness data, since a prover is what hands it over.
+	let layer_wires = digest_wires(&builder, layer.len());
+	verify_layer(&builder, root_wires, &layer_wires);
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	populate_digest(&mut w, &root_wires, root);
+	fill_digests(&mut w, &layer_wires, layer);
+
+	// Evaluating the fold is where a wrong layer is caught, so the error is returned to the caller.
+	circuit.populate_wire_witness(&mut w)?;
+	// A witness that populated must satisfy the constraint system, so this failing is a defect.
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("a satisfied circuit must verify");
+	Ok(())
+}
+
+#[test]
+fn verify_layer_accepts_prover_layers() {
+	let mut rng = StdRng::seed_from_u64(4);
+	let prover = Prover::new();
+
+	// Invariant: a layer the native committer decommits folds back to the committed root, at every
+	// depth the tree has.
+	//
+	// Fixture state: depth 3 tree, 8 leaves, 2 elements each, so 16 committed values.
+	let (batch_size, log_len) = (2, 3);
+	let data = random_values(&mut rng, batch_size << log_len);
+	let (commitment, tree) = prover.commit(&data, batch_size);
+
+	// Depth 0 is the root on its own, depth 3 the whole leaf layer, so both extremes are covered.
+	for layer_depth in 0..=log_len {
+		// The digests a native decommitment at this depth would send, one per node there.
+		let layer = prover.layer(&tree, layer_depth);
+
+		// Anchor the fixture: the native verifier accepts this layer at this depth.
+		// Without it the circuit could agree with a committer that was itself wrong.
+		prover
+			.scheme()
+			.verify_layer(&commitment.root, layer_depth, layer)
+			.expect("the prover's own layer must verify natively");
+
+		// The same digests as plain bytes, which is the form a witness carries.
+		let bytes: Vec<[u8; 32]> = layer.iter().map(digest_bytes).collect();
+		run_layer(&digest_bytes(&commitment.root), &bytes)
+			.expect("the layer must fold to the committed root");
+	}
+}
+
+#[test]
+fn verify_layer_rejects_a_corrupted_digest() {
+	let mut rng = StdRng::seed_from_u64(5);
+	let prover = Prover::new();
+
+	// Invariant: a layer with one altered entry cannot fold to the committed root.
+	//
+	// Fixture state: depth 2 tree, 4 leaves, 1 element each, layer at depth 2, so the layer is
+	// the leaf layer and holds 4 digests.
+	let (batch_size, log_len, layer_depth) = (1, 2, 2);
+	let data = random_values(&mut rng, batch_size << log_len);
+	let (commitment, tree) = prover.commit(&data, batch_size);
+
+	let mut bytes: Vec<[u8; 32]> = prover
+		.layer(&tree, layer_depth)
+		.iter()
+		.map(digest_bytes)
+		.collect();
+	// Mutation: flip the lowest bit of the second entry.
+	//
+	//     layer   :  [d_0, d_1, d_2, d_3]  ->  [d_0, d_1 ^ 1, d_2, d_3]
+	//     level 1 :  node(d_0, d_1)        ->  a different left parent
+	//     level 2 :  the top digest inherits the difference, so it misses the root
+	bytes[1][0] ^= 1;
+
+	let error = run_layer(&digest_bytes(&commitment.root), &bytes)
+		.expect_err("a corrupted layer entry must not fold to the root");
+	// The root comparison is the check that must catch this, not some unrelated assertion.
+	assert_failed_paths(&error, ".verify_layer.root");
+}
+
+/// Builds a circuit that rebuilds a whole committed vector's root, and reports the outcome.
+///
+/// The values arrive in leaf order, with a fixed number of them under each leaf.
+fn run_vector(data: &[B128], batch_size: usize, root: &[u8; 32]) -> Result<(), PopulateError> {
+	let builder = CircuitBuilder::new();
+	// The committed root is public and the committed values are witness data.
+	let root_wires: Digest = array::from_fn(|_| builder.add_inout());
+	let wires = element_wires(&builder, data.len());
+	verify_vector(&builder, root_wires, &wires, batch_size);
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	populate_digest(&mut w, &root_wires, root);
+	fill_elements(&mut w, &wires, data);
+
+	// Every leaf hash and every inner node is evaluated here, so a wrong value is caught here.
+	circuit.populate_wire_witness(&mut w)?;
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("a satisfied circuit must verify");
+	Ok(())
+}
+
+#[test]
+fn verify_vector_accepts_prover_commitments() {
+	let mut rng = StdRng::seed_from_u64(6);
+	let prover = Prover::new();
+
+	// Invariant: rebuilding the tree over the committed values in-circuit reaches the root the
+	// native committer published.
+	//
+	// Fixture state: leaf counts from a single leaf up to 16, with leaf widths that land both
+	// mid-block and on a block boundary.
+	//
+	//     1 leaf,   1 element    the single-leaf tree, where no node is folded
+	//     1 leaf,   16 elements  a leaf spanning five hash blocks
+	//     2 leaves, 1 element    one node above two leaves
+	//     4 leaves, 3 elements   48-byte leaves, so the padding lands mid-block
+	//     8 leaves, 2 elements   an even leaf count that pairs at every level
+	//     16 leaves, 1 element   the widest tree here, four levels of folding
+	for (log_len, batch_size) in [(0, 1), (0, 16), (1, 1), (2, 3), (3, 2), (4, 1)] {
+		let data = random_values(&mut rng, batch_size << log_len);
+		let (commitment, _) = prover.commit(&data, batch_size);
+		// Anchor the fixture: the native verifier accepts this vector against this root.
+		prover
+			.scheme()
+			.verify_vector(&commitment.root, &data, batch_size)
+			.expect("the prover's own vector must verify natively");
+
+		run_vector(&data, batch_size, &digest_bytes(&commitment.root))
+			.expect("the gadget must rebuild the committed root");
+	}
+}
+
+#[test]
+fn verify_vector_rejects_a_corrupted_value() {
+	let mut rng = StdRng::seed_from_u64(7);
+	let prover = Prover::new();
+
+	// Invariant: changing one committed value stops the rebuilt tree reaching the committed root.
+	//
+	// Fixture state: depth 2 tree, 4 leaves, 2 elements each, so 8 committed values.
+	let (batch_size, log_len) = (2, 2);
+	let mut data = random_values(&mut rng, batch_size << log_len);
+	let (commitment, _) = prover.commit(&data, batch_size);
+
+	// Mutation: add one to the fourth value, which is the second element of leaf 1.
+	//
+	//     leaf 1  :  hash(v_2, v_3)  ->  hash(v_2, v_3 + 1)
+	//     level 1 :  node(leaf 0, leaf 1) changes with it
+	//     root    :  differs, so the equality assertion fails
+	data[3] += B128::from(1u128);
+	let error = run_vector(&data, batch_size, &digest_bytes(&commitment.root))
+		.expect_err("a corrupted value must not rebuild the root");
+	assert_failed_paths(&error, ".verify_vector.root");
+}
+
+/// One native opening, in the byte form the gadget's witness needs.
+struct Opening {
+	/// The opened leaf's values.
+	values: Vec<B128>,
+	/// One sibling per level, from the leaf up to the decommitted layer.
+	branch: Vec<[u8; 32]>,
+	/// The decommitted layer, one digest per node at its own depth.
+	layer: Vec<[u8; 32]>,
+}
+
+/// Commits a vector, then produces the native opening of one leaf down to a chosen layer depth.
+///
+/// The authentication path travels through a transcript, exactly as it reaches a verifier.
+fn prove_opening(
+	data: &[B128],
+	batch_size: usize,
+	log_len: usize,
+	layer_depth: usize,
+	index: usize,
+) -> Opening {
+	let prover = Prover::new();
+	// A fresh tree over the data, so the opening below is one this tree really supports.
+	let (_, tree) = prover.commit(data, batch_size);
+
+	// The opening is written into a transcript and read back out, so the bytes are the ones a
+	// verifier would actually see.
+	let mut writer = ProverTranscript::new(Challenger::default());
+	prover.prove_opening(&tree, layer_depth, index, &mut writer.message());
+	let mut reader = writer.into_verifier();
+	let mut message = reader.message();
+	// One sibling per level between the leaf and the layer, in climbing order.
+	let branch = (0..log_len - layer_depth)
+		.map(|_| {
+			digest_bytes(
+				&message
+					.read::<Output<Sha256>>()
+					.expect("the prover wrote one sibling per level"),
+			)
+		})
+		.collect();
+
+	Opening {
+		// The opened leaf's values are a contiguous run of the committed data.
+		values: data[index * batch_size..(index + 1) * batch_size].to_vec(),
+		branch,
+		// The whole layer, since a verifier picks the entry itself rather than being told it.
+		layer: prover
+			.layer(&tree, layer_depth)
+			.iter()
+			.map(digest_bytes)
+			.collect(),
+	}
+}
+
+/// Builds a circuit that verifies one opening against its layer, and reports the outcome.
+///
+/// The claimed index is a parameter of its own, rather than being read off the opening.
+/// That is what lets a negative test point the check at a leaf the path does not belong to.
+fn run_opening(
+	opening: &Opening,
+	layer_depth: usize,
+	tree_depth: usize,
+	claimed_index: u64,
+) -> Result<(), PopulateError> {
+	let builder = CircuitBuilder::new();
+	// The index is public, matching a caller that derives it from sampled challenge bits.
+	let index = builder.add_inout();
+	// Leaf values and siblings are witness data, the parts of an opening a prover supplies.
+	let values = element_wires(&builder, opening.values.len());
+	let branch = digest_wires(&builder, opening.branch.len());
+	// The layer is public, since it is checked once against the root and shared by every query.
+	let layer: Vec<Digest> = (0..opening.layer.len())
+		.map(|_| array::from_fn(|_| builder.add_inout()))
+		.collect();
+	verify_opening(&builder, index, &values, layer_depth, tree_depth, &layer, &branch);
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	// The index the witness claims, which need not be the one the path was produced for.
+	w[index] = Word(claimed_index);
+	fill_elements(&mut w, &values, &opening.values);
+	fill_digests(&mut w, &branch, &opening.branch);
+	fill_digests(&mut w, &layer, &opening.layer);
+
+	// The leaf hash, the climb and the layer lookup are all evaluated here.
+	circuit.populate_wire_witness(&mut w)?;
+	circuit
+		.constraint_system()
+		.verify(&w.into_value_vec())
+		.expect("a satisfied circuit must verify");
+	Ok(())
+}
+
+#[test]
+fn verify_opening_accepts_prover_openings() {
+	let mut rng = StdRng::seed_from_u64(8);
+
+	// Invariant: every opening the native committer produces climbs to the layer entry its index
+	// addresses.
+	//
+	// Fixture state: five tree shapes, each exercised at every layer depth and every leaf index.
+	//
+	//     1 leaf,    1 element    the single-leaf tree, where the layer is the leaf itself
+	//     2 leaves,  16 elements  a leaf spanning five hash blocks
+	//     4 leaves,  3 elements   48-byte leaves, so the padding lands mid-block
+	//     8 leaves,  1 element    up to a three-level climb
+	//     16 leaves, 2 elements   up to a four-level climb
+	for (log_len, batch_size) in [(0, 1), (1, 16), (2, 3), (3, 1), (4, 2)] {
+		let data = random_values(&mut rng, batch_size << log_len);
+		// At depth 0 the layer is the root alone, so the climb spans the whole tree.
+		// At the full depth the climb is empty and the leaf digest is looked up directly.
+		for layer_depth in 0..=log_len {
+			// Every index, so every pattern of left and right pair orderings is covered.
+			for index in 0..(1usize << log_len) {
+				let opening = prove_opening(&data, batch_size, log_len, layer_depth, index);
+				// The claimed index is the true one, so this shape must be accepted.
+				run_opening(&opening, layer_depth, log_len, index as u64).unwrap_or_else(|error| {
+					panic!("opening {index} at layer {layer_depth} of 2^{log_len}: {error}")
+				});
+			}
+		}
+	}
+}
+
+#[test]
+fn verify_opening_rejects_a_corrupted_sibling() {
+	let mut rng = StdRng::seed_from_u64(9);
+
+	// Invariant: an authentication path with one altered sibling cannot climb to the entry the
+	// index addresses.
+	//
+	// Fixture state: depth 3 tree, 8 leaves, 2 elements each, layer at depth 1, index 5.
+	// The climb is two levels, and index 5 in binary is 101, so the layer entry is 1.
+	let (batch_size, log_len, layer_depth, index) = (2, 3, 1, 5);
+	let data = random_values(&mut rng, batch_size << log_len);
+	let mut opening = prove_opening(&data, batch_size, log_len, layer_depth, index);
+
+	// Mutation: flip the lowest bit of the sibling used at the bottom level.
+	//
+	//     level 0 :  node(sibling ^ 1, leaf digest)  ->  a different parent
+	//     level 1 :  the node above inherits the difference
+	//     layer   :  the arriving digest no longer equals entry 1
+	opening.branch[0][0] ^= 1;
+	let error = run_opening(&opening, layer_depth, log_len, index as u64)
+		.expect_err("a corrupted sibling must not climb to the layer");
+	assert_failed_paths(&error, ".verify_opening.layer_digest");
+}
+
+#[test]
+fn verify_opening_rejects_a_corrupted_leaf_value() {
+	let mut rng = StdRng::seed_from_u64(10);
+
+	// Invariant: an opening only verifies for the leaf values that were committed.
+	//
+	// Fixture state: depth 3 tree, 8 leaves, 2 elements each, layer at depth 1, index 5.
+	let (batch_size, log_len, layer_depth, index) = (2, 3, 1, 5);
+	let data = random_values(&mut rng, batch_size << log_len);
+	let mut opening = prove_opening(&data, batch_size, log_len, layer_depth, index);
+
+	// Mutation: add one to the first of the two values under the opened leaf.
+	//
+	//     leaf    :  hash(v_0, v_1)  ->  hash(v_0 + 1, v_1)
+	//     climb   :  the siblings are untouched, so both levels carry the difference upward
+	//     layer   :  the arriving digest no longer equals entry 1
+	opening.values[0] += B128::from(1u128);
+	let error = run_opening(&opening, layer_depth, log_len, index as u64)
+		.expect_err("a corrupted leaf value must not climb to the layer");
+	assert_failed_paths(&error, ".verify_opening.layer_digest");
+}
+
+#[test]
+fn verify_opening_rejects_a_wrong_index() {
+	let mut rng = StdRng::seed_from_u64(11);
+
+	// Invariant: an opening verifies only at the index its path belongs to, since the index both
+	// orders every pair on the climb and picks the layer entry.
+	//
+	// Fixture state: depth 3 tree, 8 leaves, 2 elements each, layer at depth 1, true index 5.
+	// Index 5 is binary 101, so bits 0 and 1 order the climb and bit 2 addresses the layer.
+	let (batch_size, log_len, layer_depth, index) = (2, 3, 1, 5);
+	let data = random_values(&mut rng, batch_size << log_len);
+	let opening = prove_opening(&data, batch_size, log_len, layer_depth, index);
+
+	// Mutation: keep the path and the layer, but claim a different index.
+	//
+	//     0 = 000, 4 = 100 :  bit 0 differs, so level 0 orders its pair the other way
+	//     7 = 111          :  bit 1 differs, so level 1 orders its pair the other way
+	//     1 = 001          :  the climb still matches, but bit 2 picks the other layer entry
+	for wrong in [0u64, 1, 4, 7] {
+		let error = run_opening(&opening, layer_depth, log_len, wrong)
+			.expect_err("an index the branch does not belong to must fail");
+		// Whichever bit differs, the same final comparison against the layer catches it.
+		assert_failed_paths(&error, ".verify_opening.layer_digest");
+	}
+}
+
+/// AND constraints one climbed level of an opening costs.
+///
+/// The module docs derive the layer-depth trade-off from this number, so a change here means the
+/// trade-off needs re-deriving.
+const LEVEL_AND: usize = 738;
+
+/// AND constraints one inner node costs on its own core.
+const NODE_AND: usize = 742;
+
+/// AND constraints one inner node costs when it shares a core with a second node.
+const PAIRED_NODE_AND: usize = 380;
+
+/// The AND and BMUL constraint counts of a circuit the caller builds.
+fn cost(build: impl FnOnce(&CircuitBuilder)) -> (usize, usize) {
+	let builder = CircuitBuilder::new();
+	// The caller emits the gadget under measurement, and nothing else.
+	build(&builder);
+	// Counting after building means constant folding and pruning are already accounted for.
+	let stat = CircuitStat::collect(&builder.build());
+	// The two columns are separate budgets, so neither can stand in for the other.
+	(stat.n_and_constraints, stat.n_bmul_constraints)
+}
+
+/// The cost of verifying one opening of a given tree shape, layer depth and leaf width.
+fn opening_cost(tree_depth: usize, layer_depth: usize, leaf_size: usize) -> (usize, usize) {
+	cost(|builder| {
+		// The same wire roles a real verifier would use, so the cost is the real one.
+		let index = builder.add_inout();
+		let values = element_wires(builder, leaf_size);
+		// One sibling per level between the leaf and the layer.
+		let branch = digest_wires(builder, tree_depth - layer_depth);
+		// A layer at depth L holds 2^L entries, which is what the entry lookup ranges over.
+		let layer: Vec<Digest> = (0..1usize << layer_depth)
+			.map(|_| array::from_fn(|_| builder.add_inout()))
+			.collect();
+		verify_opening(builder, index, &values, layer_depth, tree_depth, &layer, &branch);
+	})
+}
+
+#[test]
+fn verify_opening_follows_the_documented_cost_model() {
+	// Invariant: an opening's AND cost is affine in the number of climbed levels, and its select
+	// cost is exactly the pair ordering plus the layer lookup.
+	//
+	// Fixture state: depth 20 trees with one-element leaves, at five layer depths.
+	// Each shape is measured again one level deeper, so the difference isolates one level.
+	for layer_depth in [0usize, 1, 4, 7, 8] {
+		let (and, bmul) = opening_cost(20, layer_depth, 1);
+		let (deeper_and, deeper_bmul) = opening_cost(21, layer_depth, 1);
+
+		// Ordering a pair is eight selects, one per wire of each side.
+		// Picking the layer entry is four selects per lookup node, and a 2^L-wide lookup has
+		// 2^L - 1 of them, so this count is exact rather than a bound.
+		assert_eq!(
+			bmul,
+			8 * (20 - layer_depth) + 4 * ((1 << layer_depth) - 1),
+			"BMUL at layer depth {layer_depth}"
+		);
+		// A deeper tree at the same layer depth climbs one more level, hence orders one more pair.
+		assert_eq!(deeper_bmul - bmul, 8, "one more level orders one more pair");
+
+		// Per climbed level the AND cost is one node hash and nothing else, at every layer depth.
+		assert_eq!(
+			deeper_and - and,
+			LEVEL_AND,
+			"AND per climbed level at layer depth {layer_depth}"
+		);
+
+		// Printed so the figures quoted in the module docs can be re-read off a test run.
+		println!("verify_opening depth=20 layer={layer_depth} leaf=1: AND={and} BMUL={bmul}");
+	}
+
+	// A wider leaf hashes more blocks, which moves the constant term but not the per-level slope.
+	let (narrow, _) = opening_cost(20, 7, 1);
+	let (wide, _) = opening_cost(20, 7, 16);
+	println!("verify_opening depth=20 layer=7 leaf=16: AND={wide}");
+	assert!(wide > narrow, "a sixteen-element leaf hashes more blocks than a one-element leaf");
+}
+
+#[test]
+fn two_lane_packing_nearly_halves_a_node() {
+	// Invariant: two inner nodes sharing one compression core cost about what one node costs on
+	// its own, since a gate costs one constraint whatever its operand width.
+	//
+	//     one node  on its own core :  the low 32-bit lane works, the high one idles
+	//     two nodes on a shared core:  both lanes work, one node each
+	let (single, _) = cost(|builder| {
+		// Two children in, one node digest out, pinned to a public claim.
+		let inputs = digest_wires(builder, 2);
+		let claimed: Digest = array::from_fn(|_| builder.add_inout());
+		builder.assert_eq_v("node", compress_node(builder, inputs[0], inputs[1]), claimed);
+	});
+	let (paired, _) = cost(|builder| {
+		// Four children give two independent nodes, which is what lets them share a core.
+		let inputs = digest_wires(builder, 4);
+		let claimed: [Digest; 2] = array::from_fn(|_| array::from_fn(|_| builder.add_inout()));
+		let computed = compress_node_2x(builder, [(inputs[0], inputs[1]), (inputs[2], inputs[3])]);
+		for lane in 0..2 {
+			builder.assert_eq_v(format!("node[{lane}]"), computed[lane], claimed[lane]);
+		}
+	});
+	println!("compress_node: AND={single}, compress_node_2x: AND={paired}");
+
+	assert_eq!(single, NODE_AND, "AND per lone node");
+	// Halving the pair's cost gives the per-node figure the module docs quote.
+	assert_eq!(paired / 2, PAIRED_NODE_AND, "AND per node when two share a core");
+}
+
+#[test]
+fn two_lane_packing_nearly_halves_a_single_block_leaf() {
+	// Invariant: two narrow leaves hashed in separate lanes cost about what one costs alone.
+	//
+	// Fixture state: one element is 16 bytes, so a padded one-element leaf is a single block.
+	// Equal block counts let the two lanes run end to end with no leftover single-lane core.
+	let leaf_cost = |n_leaves: usize| {
+		cost(|builder| {
+			// One element per leaf, so the leaf count is also the element count.
+			let values = element_wires(builder, n_leaves);
+			// Every digest is pinned, or dead-code elimination prunes the hashing away.
+			let claimed: Vec<Digest> = (0..n_leaves)
+				.map(|_| array::from_fn(|_| builder.add_inout()))
+				.collect();
+			// A lone leaf uses the single-lane path, a pair the two-lane one.
+			if n_leaves == 1 {
+				builder.assert_eq_v("leaf", leaf_digest(builder, &values[..1]), claimed[0]);
+			} else {
+				let computed = leaf_digest_2x(builder, [&values[..1], &values[1..2]]);
+				for lane in 0..2 {
+					builder.assert_eq_v(format!("leaf[{lane}]"), computed[lane], claimed[lane]);
+				}
+			}
+		})
+	};
+	let (single, _) = leaf_cost(1);
+	let (paired, _) = leaf_cost(2);
+	println!("leaf_digest: AND={single}, leaf_digest_2x: AND={paired}");
+
+	// The one-eighth margin covers merging the two lanes and splitting them apart again.
+	assert!(paired < single + single / 8, "two paired leaves must cost about one lone leaf");
+}
+
+#[test]
+fn verify_layer_costs_one_paired_node_per_inner_node() {
+	// Invariant: folding a layer to its root spends one shared-core node hash per inner node, and
+	// no selects at all.
+	//
+	// Fixture state: layers 2, 16 and 128 digests wide, holding 1, 15 and 127 inner nodes above
+	// them.
+	for layer_depth in [1usize, 4, 7] {
+		let (and, bmul) = cost(|builder| {
+			// A public root claim over a layer of witness digests, as a verifier holds them.
+			let root: Digest = array::from_fn(|_| builder.add_inout());
+			let layer = digest_wires(builder, 1usize << layer_depth);
+			verify_layer(builder, root, &layer);
+		});
+		println!("verify_layer layer={layer_depth}: AND={and} BMUL={bmul}");
+
+		// Folding is pure hashing, with no pair to order, so no select gate can appear.
+		assert_eq!(bmul, 0, "the fold uses no select gates");
+
+		// Every node but the top one has a neighbour at its own level to share a core with.
+		let n_nodes = (1usize << layer_depth) - 1;
+		// A two-digest layer has only the top node, so its average is not a fair comparison.
+		if n_nodes > 1 {
+			assert!(
+				and / n_nodes <= PAIRED_NODE_AND + PAIRED_NODE_AND / 8,
+				"AND per node at layer depth {layer_depth} is {}",
+				and / n_nodes
+			);
+		}
+	}
+}


### PR DESCRIPTION
Closes [BINIUS-430](https://linear.app/jimpo/issue/BINIUS-430).

Circuit gadgets matching the native binary Merkle scheme, so a recursive circuit can check the openings a native prover produced.
Rebased onto the merged recursion skeleton (#2093), so this is now purely additive: one new module, plus three lines of manifest and five of crate docs.

### Where this slots in

#2093 landed the pipeline but left the Merkle openings unconstrained, which its own crate docs call out. Two sites in the merged channel are waiting on these gadgets:

```
channel.rs:247  recv_openings          UNCONSTRAINED: nothing binds the opened values to the
                                       root. Hashing each leaf and climbing the path is the
                                       gadget this skeleton leaves out.
channel.rs:258  recv_committed_vector  UNCONSTRAINED: nothing rebuilds the tree over the vector.
```

This PR adds those gadgets and their tests against a real native prover. It deliberately does **not** rewire the two call sites — that is a separate, reviewable change, and doing it here would mix new primitives with a change to the channel's soundness story. So the skeleton stays exactly as sound as it is today, and the crate docs now say where the missing pieces live.

### The problem

A recursive verifier spends most of its constraints checking Merkle openings.
To do that it needs gadgets that agree with the native scheme *exactly* — same padding, same domain separation, same layer choice — or the circuit rejects honest proofs.

### The shape being matched

```
leaf digest   full padded SHA-256 over the leaf's elements, 16 little-endian bytes each
inner node    one raw compression over the 64-byte pair of child digests, no padding
```

The inner node starts from a domain-separating initial state rather than the standard one, which is what stops a leaf hash being replayed as a node hash.

### The index is a wire

FRI samples query indices inside the protocol, so an index is not known while building.
That decides the shape of everything:

- the pair ordering at each level is driven by an index bit
- the layer entry is chosen by a multiplexer over the index's high bits
- the gadget verifies at the index reduced modulo the leaf count, since no build-time range check is possible

### The stale cost figure

The number recorded on the issue was wrong, and in an instructive way.

- A single-lane compression measures **726 AND**, not ~368.
- The ~368 was a *per-block* figure for a gadget that already pairs blocks two-lane.

Since every gate costs one constraint regardless of width, two independent hashes can share a 64-bit datapath, one per 32-bit lane. Both places with independent work take that route:

| gadget | AND per node |
|---|---|
| one node, single-lane | 742 |
| one node, two-lane | 380 |
| a layer fold | ~380 |

A climb cannot use it — it is strictly sequential, so an opening cannot share cores with itself.

### Per opening

The cost model is exact, and pinned by a test at two tree depths and five layer depths:

```
AND  = leaf + 738 * (D - L)
BMUL = 8 * (D - L) + 4 * (2^L - 1)
```

for tree depth `D` and layer depth `L`.

### Re-deriving the layer depth

Raising `L` by one, per query out of `n_q` queries:

```
dAND  = -738 + 380 * 2^L / n_q
dBMUL = +4 * 2^L - 8
```

- The **AND** column breaks even at `2^L = 1.94 * n_q`, one level *above* the native choice of `ceil(log2(n_q))`.
- The **BMUL** column gains nothing past `L = 1`, since the multiplexer grows with the layer while the climb it shortens is only 8 selects per level.

These fill separate constraint columns, so there is no single budget to minimise — which one is scarce depends on what the rest of the circuit already put in each.
At depth 20 with 100 queries, AND leads BMUL by more than 10x, so the AND column decides: `L = 8` on AND alone, `L = 7` once BMUL is charged at the same rate.

Either way it tracks `log2(n_q)` rather than being a constant. Tuning the surrounding FRI parameters is [BINIUS-428](https://linear.app/jimpo/issue/BINIUS-428).

### One lever left open

Two *different* openings are independent, so they could share cores across queries at ~380 AND per level per query.
That is not done here, because it halves the per-query saving from raising `L` and moves the AND-optimal depth down by about one — worth doing together with the parameter tuning rather than in isolation.

### One duplication to fold in later

`channel.rs` already carries a private `DIGEST_WORDS`, and this module exports its own.
They agree, and they live in different modules so nothing breaks, but a protocol constant defined twice will drift.
I left `channel.rs` alone rather than refactor freshly-merged code inside a rebase — folding the two together belongs with the change that wires these gadgets into the channel.

### Scope

- **new:** `crates/recursion/src/merkle.rs` and its tests
- **changed:** `Cargo.toml` gains three dev-dependencies; `lib.rs` gains the module and a docs paragraph
- **left out:** wiring the gadgets into `recv_openings` / `recv_committed_vector`, cross-query two-lane pairing, and unifying `DIGEST_WORDS`

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-recursion --all-targets --all-features -- -D warnings` — clean
- nightly `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-recursion --no-deps` — clean
- `cargo test -p binius-recursion` and `--all-features` — 19 new tests pass, and the skeleton's 3 still pass

Coverage is against trees, layers and openings from the real native prover, with branches read back through a real transcript:

- leaf digests at sizes 1, 2, 3, 4, 5, 8 and 16, differential against the native serializing hash — 3 and 5 land mid-block
- inner nodes differential against the native compression, and the domain-separating state recomputed from its own preimage
- openings over five tree shapes x **every** layer depth x **every** index, covering the single-leaf tree and the case where the layer sits at the leaves
- negatives: corrupted sibling, corrupted leaf value, four wrong indices, corrupted layer digest, corrupted vector entry

Each negative asserts on every field of the resulting error, with no discarded fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
