### PR TITLE
BINIUS-461: fix the FRI domain to the Gao-Mateer basis in ReedSolomonCode

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -620,10 +620,10 @@ mod tests {
 		merkle_tree::BinaryMerkleTreeScheme,
 	};
 	use binius_math::{
-		BinarySubspace, FieldBuffer,
+		FieldBuffer,
 		inner_product::inner_product_buffers,
 		multilinear::eq::eq_ind_partial_eval,
-		ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly},
+		ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 		test_utils::{random_field_buffer, random_scalars},
 	};
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
@@ -642,9 +642,9 @@ mod tests {
 	}
 
 	fn make_ntt(
-		subspace: &BinarySubspace<BinaryField128bGhash>,
-	) -> NeighborsLastSingleThread<GenericOnTheFly<BinaryField128bGhash>> {
-		let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
+		log_domain_size: usize,
+	) -> NeighborsLastSingleThread<GaoMateerOnTheFly<BinaryField128bGhash>> {
+		let domain_context = GaoMateerOnTheFly::generate(log_domain_size);
 		NeighborsLastSingleThread::new(domain_context)
 	}
 
@@ -691,7 +691,7 @@ mod tests {
 		);
 
 		// === PROVER SIDE ===
-		let ntt = make_ntt(verifier_compiler.max_subspace());
+		let ntt = make_ntt(verifier_compiler.max_log_domain_size());
 		let prover_compiler =
 			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
@@ -763,7 +763,7 @@ mod tests {
 		);
 
 		// === PROVER SIDE ===
-		let ntt = make_ntt(verifier_compiler.max_subspace());
+		let ntt = make_ntt(verifier_compiler.max_log_domain_size());
 		let prover_compiler =
 			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
@@ -846,7 +846,7 @@ mod tests {
 		);
 
 		// === PROVER SIDE ===
-		let ntt = make_ntt(verifier_compiler.max_subspace());
+		let ntt = make_ntt(verifier_compiler.max_log_domain_size());
 		let prover_compiler =
 			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
@@ -942,7 +942,7 @@ mod tests {
 			&MinProofSizeStrategy,
 		);
 
-		let ntt = make_ntt(verifier_compiler.max_subspace());
+		let ntt = make_ntt(verifier_compiler.max_log_domain_size());
 		let prover_compiler =
 			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
 

--- a/crates/iop-prover/src/basefold/compiler.rs
+++ b/crates/iop-prover/src/basefold/compiler.rs
@@ -70,7 +70,6 @@ where
 		// oracle's batch size from its ZK flag: ZK oracles fix `log_batch_size = 1` (message ‖
 		// equal-length mask); non-ZK oracles take a flexible batch size.
 		let (fri_params, _) = FRIParams::optimal_for_batch(
-			ntt.domain_context(),
 			merkle_scheme,
 			&oracle_specs,
 			log_inv_rate,

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -117,11 +117,11 @@ mod test {
 	use binius_ip::channel::IPVerifierChannel;
 	use binius_ip_prover::channel::IPProverChannel;
 	use binius_math::{
-		BinarySubspace, FieldBuffer,
+		FieldBuffer,
 		inner_product::inner_product_buffers,
 		line::extrapolate_line_packed,
 		multilinear::eq::eq_ind_partial_eval,
-		ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
+		ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 		test_utils::{random_field_buffer, random_scalars},
 	};
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
@@ -159,15 +159,13 @@ mod test {
 
 		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 
-		let subspace = BinarySubspace::with_dim(n_vars + 1 + LOG_INV_RATE);
-		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+		let domain_context = GaoMateerOnTheFly::generate(n_vars + 1 + LOG_INV_RATE);
 		let ntt = NeighborsLastSingleThread::new(domain_context);
 
 		// For a single oracle the combined opening params (`optimal_for_batch`) also satisfy
 		// `encode_masked`'s preconditions (`log_batch_size() == 1`, `rs_code().log_dim() ==
 		// n_vars`).
 		let (fri_params, _) = binius_iop::fri::FRIParams::optimal_for_batch(
-			ntt.domain_context(),
 			merkle_prover.scheme(),
 			&[OracleSpec::new_zk(n_vars)],
 			LOG_INV_RATE,

--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -54,11 +54,11 @@ where
 		"precondition: interleaved message length must match the oracle's spec"
 	);
 
-	// Encode this oracle at its own dimension (≤ the batched code's reduced dimension), over the
-	// same subspace and rate as the batched code. `encode_batch` checks the subspace matches the
-	// NTT, which is how the per-oracle codeword stays consistent with the combined fold's lift.
-	let rs_code =
-		ReedSolomonCode::with_ntt_subspace(ntt, oracle_log_dim, params.rs_code().log_inv_rate());
+	// Encode this oracle at its own dimension (≤ the batched code's reduced dimension), at the
+	// same rate as the batched code. Both codes evaluate over the Gao-Mateer basis, the shorter
+	// one over a prefix of the longer's, which is how the per-oracle codeword stays consistent
+	// with the combined fold's lift. `encode_batch` checks the NTT agrees with that domain.
+	let rs_code = ReedSolomonCode::new(oracle_log_dim, params.rs_code().log_inv_rate());
 
 	let _scope = tracing::debug_span!(
 		"Reed–Solomon Encode",
@@ -155,8 +155,7 @@ mod tests {
 	use binius_hash::StdHashSuite;
 	use binius_iop::fri::FRIParams;
 	use binius_math::{
-		BinarySubspace,
-		ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly},
+		ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 		test_utils::random_field_buffer,
 	};
 	use rand::{SeedableRng, rngs::StdRng};
@@ -178,12 +177,10 @@ mod tests {
 
 		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 
-		let subspace = BinarySubspace::with_dim(log_dim + log_inv_rate);
-		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+		let domain_context = GaoMateerOnTheFly::generate(log_dim + log_inv_rate);
 		let ntt = NeighborsLastSingleThread::new(domain_context);
 
 		let params = FRIParams::with_strategy(
-			ntt.domain_context(),
 			merkle_prover.scheme(),
 			log_dim + log_batch_size,
 			Some(log_batch_size),

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -14,9 +14,9 @@ use binius_iop::{
 use binius_ip::channel::IPVerifierChannel;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	BinarySubspace, ReedSolomonCode,
+	ReedSolomonCode,
 	multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
-	ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
+	ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly},
 	test_utils::{Packed128b, random_field_buffer},
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
@@ -45,8 +45,7 @@ fn test_commit_prove_verify_success<F, P>(
 	let params =
 		FRIParams::new(committed_rs_code, log_batch_size, arities.to_vec(), n_test_queries);
 
-	let subspace = BinarySubspace::with_dim(params.rs_code().log_len());
-	let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+	let domain_context = GaoMateerOnTheFly::generate(params.rs_code().log_len());
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 
 	let n_round_commitments = arities.len();
@@ -227,8 +226,7 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 
 	// The reduced Reed-Solomon code is shared by every input oracle, so the domain only needs to
 	// cover its length.
-	let subspace = BinarySubspace::with_dim(log_dim + log_inv_rate);
-	let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+	let domain_context = GaoMateerOnTheFly::generate(log_dim + log_inv_rate);
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 
 	// Each oracle has RS dimension `log_dim` (no lifting), so every oracle sits at the reduced
@@ -243,8 +241,7 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 			log_later_batch_size: log_batch_size,
 		})
 		.collect::<Vec<_>>();
-	let rs_code =
-		ReedSolomonCode::with_domain_context_subspace(ntt.domain_context(), log_dim, log_inv_rate);
+	let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate);
 	let params = FRIParams::<F>::new_batch(rs_code, oracle_specs, vec![], n_test_queries);
 	assert_eq!(params.rs_code().log_dim(), log_dim);
 
@@ -365,8 +362,7 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 
 	// Every oracle reduces to the shared dimension `log_dim`, so no lifting is exercised here — the
 	// focus is the inner-challenge windowing.
-	let subspace = BinarySubspace::with_dim(log_dim + log_inv_rate);
-	let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+	let domain_context = GaoMateerOnTheFly::generate(log_dim + log_inv_rate);
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 
 	// Every oracle sits at the reduced dimension `log_dim` (no lifting). The ZK oracle (batch 1)
@@ -380,8 +376,7 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 			log_later_batch_size: if is_zk { 0 } else { log_batch_size },
 		})
 		.collect::<Vec<_>>();
-	let rs_code =
-		ReedSolomonCode::with_domain_context_subspace(ntt.domain_context(), log_dim, log_inv_rate);
+	let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate);
 	let params = FRIParams::<F>::new_batch(rs_code, oracle_specs, vec![], n_test_queries);
 	assert_eq!(params.rs_code().log_dim(), log_dim);
 
@@ -522,8 +517,7 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 
 	// A single shared domain context covers the reduced code; every per-oracle (smaller) code is
 	// derived from it so their subspaces are nested prefixes of the reduced subspace.
-	let subspace = BinarySubspace::with_dim(reduced_log_dim + log_inv_rate);
-	let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+	let domain_context = GaoMateerOnTheFly::generate(reduced_log_dim + log_inv_rate);
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 
 	// Each oracle is lifted from its own RS dimension up to `reduced_log_dim` (`log_lift` is the
@@ -536,11 +530,7 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 			log_later_batch_size: log_batch_size,
 		})
 		.collect::<Vec<_>>();
-	let rs_code = ReedSolomonCode::with_domain_context_subspace(
-		ntt.domain_context(),
-		reduced_log_dim,
-		log_inv_rate,
-	);
+	let rs_code = ReedSolomonCode::new(reduced_log_dim, log_inv_rate);
 	let params = FRIParams::<F>::new_batch(rs_code, oracle_specs, vec![], n_test_queries);
 	assert_eq!(params.rs_code().log_dim(), reduced_log_dim);
 
@@ -554,11 +544,7 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 	let mut messages = Vec::new();
 	let mut committed_codewords = Vec::new();
 	for (&log_dim, &log_batch_size) in iter::zip(&oracle_log_dims, &log_batch_sizes) {
-		let rs_code = ReedSolomonCode::with_domain_context_subspace(
-			ntt.domain_context(),
-			log_dim,
-			log_inv_rate,
-		);
+		let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate);
 		let oracle_params = FRIParams::new(rs_code, log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
 		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref());
@@ -676,8 +662,7 @@ where
 	let params =
 		FRIParams::new(committed_rs_code, log_batch_size, arities.to_vec(), n_test_queries);
 
-	let subspace = BinarySubspace::with_dim(params.rs_code().log_len());
-	let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+	let domain_context = GaoMateerOnTheFly::generate(params.rs_code().log_len());
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 
 	let msg = random_field_buffer::<P>(&mut rng, params.log_msg_len());

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -424,7 +424,7 @@ mod tests {
 			basefold::compiler::BaseFoldVerifierCompiler, fri::MinProofSizeStrategy,
 			merkle_tree::BinaryMerkleTreeScheme,
 		};
-		use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};
+		use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly};
 
 		use crate::basefold::compiler::BaseFoldProverCompiler;
 
@@ -455,8 +455,7 @@ mod tests {
 		);
 
 		// Prove: commit the pushforwards with real FRI, run the reduction, open them.
-		let domain_context =
-			GenericOnTheFly::generate_from_subspace(verifier_compiler.max_subspace());
+		let domain_context = GaoMateerOnTheFly::generate(verifier_compiler.max_log_domain_size());
 		let ntt = NeighborsLastSingleThread::new(domain_context);
 		let prover_compiler =
 			BaseFoldProverCompiler::<BP, _>::from_verifier_compiler(&verifier_compiler, ntt);

--- a/crates/iop/src/basefold/compiler.rs
+++ b/crates/iop/src/basefold/compiler.rs
@@ -6,7 +6,6 @@ use std::borrow::BorrowMut;
 
 use binius_field::BinaryField;
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_math::{BinarySubspace, ntt::domain_context::GaoMateerOnTheFly};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use digest::Output;
@@ -59,27 +58,11 @@ where
 			"BaseFoldVerifierCompiler requires at least one oracle spec"
 		);
 
-		// ZK oracles add 1 to the message length for the interleaved mask; non-ZK oracles do not.
-		// Compute max code length across all oracles.
-		let max_log_code_len = oracle_specs
-			.iter()
-			.map(|spec| spec.log_msg_len + usize::from(spec.is_zk))
-			.max()
-			.expect("oracle_specs is non-empty")
-			+ log_inv_rate;
-		// The whole protocol's evaluation domain is fixed here: `FRIParams` stores this context's
-		// subspace on its Reed-Solomon code, and every prover and verifier reads the domain back
-		// off that. A Gao-Mateer basis makes the folding maps all $x \mapsto x^2 + x$ with no
-		// normalization factors, and puts the early layers' twiddles in small subfields. See
-		// [`GaoMateerOnTheFly`] for the full list of properties.
-		let domain_context = GaoMateerOnTheFly::<F>::generate(max_log_code_len);
-
 		// The single combined FRI parameters over all oracles. `optimal_for_batch` chooses the fold
 		// arities to minimize proof size, so `_arity_strategy` is not consulted here. It derives
 		// each oracle's batch size from its ZK flag: ZK oracles fix `log_batch_size = 1` (message
 		// ‖ mask), non-ZK oracles take a flexible batch size.
 		let (fri_params, _) = FRIParams::optimal_for_batch(
-			&domain_context,
 			merkle_scheme,
 			&oracle_specs,
 			log_inv_rate,
@@ -102,9 +85,13 @@ where
 		&self.fri_params
 	}
 
-	/// Returns the Reed-Solomon code subspace of the combined FRI parameters (the largest needed).
-	pub fn max_subspace(&self) -> &BinarySubspace<F> {
-		self.fri_params.rs_code().subspace()
+	/// The dimension of the largest evaluation domain the combined FRI parameters need.
+	///
+	/// A prover builds its NTT domain context from this. The basis is not communicated because
+	/// [`ReedSolomonCode`](binius_math::reed_solomon::ReedSolomonCode) fixes it: the Gao-Mateer
+	/// basis of this dimension.
+	pub fn max_log_domain_size(&self) -> usize {
+		self.fri_params.rs_code().log_len()
 	}
 
 	/// Creates a ZK verifier channel over the given Merkle channel.
@@ -139,48 +126,5 @@ where
 		Output<H::LeafHash>: DeserializeBytes,
 	{
 		self.create_channel(VerifierMerkleTranscriptChannel::new(transcript))
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use binius_field::BinaryField128bGhash as B128;
-	use binius_hash::StdHashSuite;
-	use binius_math::ntt::{DomainContext, domain_context::GaoMateerPreExpanded};
-
-	use super::*;
-	use crate::{channel::OracleSpec, fri::MinProofSizeStrategy};
-
-	/// Every prover rebuilds the evaluation domain from `max_subspace().dim()` alone, rather than
-	/// from the subspace itself. That is only sound because this compiler fixed the domain as the
-	/// Gao-Mateer basis, so regenerating it at the same dimension reproduces it exactly.
-	///
-	/// This pins that agreement. Were the compiler to go back to `BinarySubspace::with_dim`, the
-	/// provers would silently encode over a different domain than the verifier checks.
-	#[test]
-	fn max_subspace_is_the_gao_mateer_basis_of_its_dimension() {
-		for oracle_specs in [
-			vec![OracleSpec::new(10)],
-			vec![OracleSpec::new_zk(10)],
-			// A batch of unequal, non-power-of-two message lengths, so the reduced dimension and
-			// the max code length come apart.
-			vec![
-				OracleSpec::new(7),
-				OracleSpec::new_zk(12),
-				OracleSpec::new(9),
-			],
-		] {
-			let compiler = BaseFoldVerifierCompiler::<B128>::new(
-				&BinaryMerkleTreeScheme::<B128, StdHashSuite>::new(),
-				oracle_specs,
-				1,
-				32,
-				&MinProofSizeStrategy,
-			);
-
-			let subspace = compiler.max_subspace();
-			let regenerated = GaoMateerPreExpanded::<B128>::generate(subspace.dim());
-			assert_eq!(regenerated.subspace(subspace.dim()), *subspace);
-		}
 	}
 }

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 
 use binius_field::{BinaryField, Field};
-use binius_math::{ntt::DomainContext, reed_solomon::ReedSolomonCode};
+use binius_math::reed_solomon::ReedSolomonCode;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use getset::{CopyGetters, Getters};
 
@@ -172,7 +172,6 @@ where
 	///
 	/// ## Arguments
 	///
-	/// * `domain_context` - the domain context providing subspaces for the Reed-Solomon code.
 	/// * `merkle_scheme` - the Merkle tree scheme used for commitments.
 	/// * `log_msg_len` - the binary logarithm of the length of the message to commit.
 	/// * `log_batch_size` - if `Some`, fixes the batch size; if `None`, the batch size is chosen
@@ -184,10 +183,7 @@ where
 	/// ## Preconditions
 	///
 	/// * If `log_batch_size` is `Some(b)`, then `b <= log_msg_len`.
-	/// * `domain_context.log_domain_size() >= log_msg_len - log_batch_size.unwrap_or(0) +
-	///   log_inv_rate`.
-	pub fn with_strategy<DC, MerkleScheme, Strategy>(
-		domain_context: &DC,
+	pub fn with_strategy<MerkleScheme, Strategy>(
 		merkle_scheme: &MerkleScheme,
 		log_msg_len: usize,
 		log_batch_size: Option<usize>,
@@ -196,7 +192,6 @@ where
 		strategy: &Strategy,
 	) -> Self
 	where
-		DC: DomainContext<Field = F>,
 		MerkleScheme: MerkleTreeScheme<F>,
 		Strategy: AritySelectionStrategy,
 	{
@@ -219,8 +214,7 @@ where
 		});
 
 		let log_dim = log_msg_len - log_batch_size;
-		let rs_code =
-			ReedSolomonCode::with_domain_context_subspace(domain_context, log_dim, log_inv_rate);
+		let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate);
 		Self::new(rs_code, log_batch_size, fold_arities, n_test_queries)
 	}
 
@@ -234,7 +228,6 @@ where
 	///
 	/// ## Arguments
 	///
-	/// * `domain_context` - the domain context providing subspaces for the Reed-Solomon code.
 	/// * `merkle_scheme` - the Merkle tree scheme used for commitments.
 	/// * `oracles` - the oracles to batch. A ZK oracle commits its message interleaved with an
 	///   equal-length mask (fixed `log_batch_size = 1`); a non-ZK oracle commits the bare message
@@ -245,17 +238,13 @@ where
 	/// ## Preconditions
 	///
 	/// * `oracles` is non-empty.
-	/// * `domain_context.log_domain_size()` is large enough for the chosen reduced dimension plus
-	///   `log_inv_rate`.
-	pub fn optimal_for_batch<DC, MerkleScheme>(
-		domain_context: &DC,
+	pub fn optimal_for_batch<MerkleScheme>(
 		merkle_scheme: &MerkleScheme,
 		oracles: &[OracleSpec],
 		log_inv_rate: usize,
 		n_test_queries: usize,
 	) -> (Self, usize)
 	where
-		DC: DomainContext<Field = F>,
 		MerkleScheme: MerkleTreeScheme<F>,
 	{
 		assert!(!oracles.is_empty()); // precondition
@@ -267,11 +256,7 @@ where
 			fold_arities,
 		} = choose_codeword_specs_for_oracles(merkle_scheme, oracles, log_inv_rate, n_test_queries);
 
-		let rs_code = ReedSolomonCode::with_domain_context_subspace(
-			domain_context,
-			reduced_log_dim,
-			log_inv_rate,
-		);
+		let rs_code = ReedSolomonCode::new(reduced_log_dim, log_inv_rate);
 
 		let params = Self::new_batch(rs_code, oracle_specs, fold_arities, n_test_queries);
 		(params, proof_size)
@@ -810,9 +795,6 @@ impl AritySelectionStrategy for ConstantArityStrategy {
 mod tests {
 	use binius_field::BinaryField128bGhash as B128;
 	use binius_hash::StdHashSuite;
-	use binius_math::ntt::{
-		AdditiveNTT, NeighborsLastReference, domain_context::GaoMateerOnTheFly,
-	};
 
 	use super::*;
 	use crate::{fri::proof_size, merkle_tree::BinaryMerkleTreeScheme};
@@ -834,11 +816,6 @@ mod tests {
 	fn optimizer_estimate_matches_exact_proof_size() {
 		let merkle_scheme = test_merkle_scheme();
 		let digest_size = size_of::<<TestMerkleScheme as MerkleTreeScheme<B128>>::Digest>();
-
-		// Large enough for the widest case below: a ZK oracle commits `log_msg_len + 1`.
-		let ntt = NeighborsLastReference {
-			domain_context: GaoMateerOnTheFly::<B128>::generate(24),
-		};
 
 		// Single oracles across the size range, then shapes that stress the batch layout: lifting,
 		// ZK mixed with flexible, non-power-of-two counts.
@@ -871,7 +848,6 @@ mod tests {
 			for n_test_queries in [32, 128, 232] {
 				for oracles in &batches {
 					let (params, estimate) = FRIParams::optimal_for_batch(
-						ntt.domain_context(),
 						&merkle_scheme,
 						oracles,
 						log_inv_rate,
@@ -930,14 +906,9 @@ mod tests {
 		let log_inv_rate = 2;
 		let n_test_queries = 128;
 
-		let ntt = NeighborsLastReference {
-			domain_context: GaoMateerOnTheFly::<B128>::generate(24 + log_inv_rate),
-		};
-
 		// log_msg_len = 0
 		{
 			let fri_params = FRIParams::with_strategy(
-				ntt.domain_context(),
 				&merkle_scheme,
 				0,
 				None,
@@ -952,7 +923,6 @@ mod tests {
 		// log_msg_len = 3
 		{
 			let fri_params = FRIParams::with_strategy(
-				ntt.domain_context(),
 				&merkle_scheme,
 				3,
 				None,
@@ -967,7 +937,6 @@ mod tests {
 		// log_msg_len = 24
 		{
 			let fri_params = FRIParams::with_strategy(
-				ntt.domain_context(),
 				&merkle_scheme,
 				24,
 				None,
@@ -986,10 +955,6 @@ mod tests {
 		let log_inv_rate = 2;
 		let n_test_queries = 128;
 
-		let ntt = NeighborsLastReference {
-			domain_context: GaoMateerOnTheFly::<B128>::generate(16 + log_inv_rate),
-		};
-
 		// Two masked ZK oracles (fixed batch size 1, committed lengths 10 and 12) and one non-ZK
 		// oracle with a flexible batch size (committed length 16). The ZK oracles lower-bound the
 		// reduced dimension; the flexible oracle folds down to it.
@@ -999,13 +964,8 @@ mod tests {
 			OracleSpec::new(16),
 		];
 
-		let (fri_params, proof_size) = FRIParams::optimal_for_batch(
-			ntt.domain_context(),
-			&merkle_scheme,
-			&oracles,
-			log_inv_rate,
-			n_test_queries,
-		);
+		let (fri_params, proof_size) =
+			FRIParams::optimal_for_batch(&merkle_scheme, &oracles, log_inv_rate, n_test_queries);
 
 		// The reduced oracle dimension is the dimension of the first FRI round oracle, equal to
 		// log_terminal_dim + sum(fold_arities).
@@ -1051,14 +1011,9 @@ mod tests {
 		let log_inv_rate = 2;
 		let n_test_queries = 128;
 
-		let ntt = NeighborsLastReference {
-			domain_context: GaoMateerOnTheFly::<B128>::generate(24 + log_inv_rate),
-		};
-
 		// log_msg_len = 3
 		{
 			let fri_params = FRIParams::with_strategy(
-				ntt.domain_context(),
 				&merkle_scheme,
 				3,
 				Some(1),
@@ -1073,7 +1028,6 @@ mod tests {
 		// log_msg_len = 24
 		{
 			let fri_params = FRIParams::with_strategy(
-				ntt.domain_context(),
 				&merkle_scheme,
 				24,
 				Some(1),

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -5,7 +5,7 @@ use std::iter::{self, repeat_with};
 
 use binius_core::word::Word;
 use binius_field::{BinaryField, FieldOps};
-use binius_math::ntt::domain_context::GenericOnTheFly;
+use binius_math::ntt::domain_context::GaoMateerOnTheFly;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 use super::{
@@ -38,7 +38,7 @@ where
 	/// Performs the first, interleaved reduction of the committed codeword(s).
 	codeword_oracle: BatchBrakedownOracle<E, C>,
 	/// Performs each subsequent FRI reduction, one per fold arity.
-	fri_oracles: Vec<FRIOracle<E, C, GenericOnTheFly<F>>>,
+	fri_oracles: Vec<FRIOracle<E, C, GaoMateerOnTheFly<F>>>,
 }
 
 impl<'a, F, E, C> FRIQueryVerifier<'a, F, E, C>
@@ -148,10 +148,10 @@ where
 
 		// All FRI reductions fold cosets of the same Reed–Solomon codeword domain, so they share a
 		// single domain context.
-		// Derived from the subspace the params carry, not regenerated from its dimension: a
-		// `FRIParams` may be built over any subspace, so the verifier cannot assume the
-		// Gao-Mateer basis the BaseFold compiler happens to choose.
-		let domain_context = GenericOnTheFly::generate_from_subspace(params.rs_code().subspace());
+		// `ReedSolomonCode` fixes the evaluation domain as the Gao-Mateer basis of its length, so
+		// the verifier rebuilds it from the code's shape rather than being told which basis the
+		// prover used.
+		let domain_context = GaoMateerOnTheFly::generate(params.rs_code().log_len());
 		let mut fri_oracles = Vec::with_capacity(params.fold_arities().len());
 		let mut depth = index_bits;
 		let mut fold_round = params.log_batch_size();
@@ -238,8 +238,7 @@ where
 
 		// Fold each coset of the terminal codeword and check that the folds are all equal, i.e.
 		// that the codeword has the claimed low degree.
-		let domain_context =
-			GenericOnTheFly::generate_from_subspace(self.params.rs_code().subspace());
+		let domain_context = GaoMateerOnTheFly::generate(self.params.rs_code().log_len());
 		let log_len = n_final_challenges + log_inv_rate;
 		let repetition_codeword = terminate_codeword
 			.chunks(1 << n_final_challenges)

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -370,7 +370,7 @@ where
 		// Reuse the verifier's evaluation domain so both sides agree on the code: its compiler
 		// fixed that domain as the Gao-Mateer basis of this dimension.
 		let domain_context =
-			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_subspace().dim());
+			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_log_domain_size());
 
 		// Spread the NTT across the available cores.
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -222,7 +222,7 @@ fn gao_mateer_basis<F: BinaryField>(num_basis_elements: usize) -> Vec<F> {
 /// folding. In both cases, all twiddles will be accessed eventually, so they might as well be
 /// precomputed. But it could possibly be used e.g. in the FRI verifier, which only accesses a few
 /// selected twiddles.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GaoMateerOnTheFly<F> {
 	/// Stores $[\beta_0, ..., \beta_{\ell-1}]$.
 	basis: Vec<F>,

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -5,18 +5,18 @@
 //!
 //! See [`ReedSolomonCode`] for details.
 
-use std::ptr;
+use std::{marker::PhantomData, ptr};
 
 use binius_field::{BinaryField, PackedField};
 use binius_utils::rayon::{prelude::*, task_size::task_chunk_len};
-use getset::{CopyGetters, Getters};
+use getset::CopyGetters;
 
 use super::{
 	FieldBuffer, FieldSlice, FieldSliceMut, binary_subspace::BinarySubspace, ntt::AdditiveNTT,
 };
 use crate::{
 	bit_reverse::{bit_reverse_indices, bit_reverse_packed},
-	ntt::DomainContext,
+	ntt::{DomainContext, domain_context::GaoMateerOnTheFly},
 };
 
 /// [Reed–Solomon] codes over binary fields.
@@ -28,58 +28,38 @@ use crate::{
 ///
 /// [Reed–Solomon]: <https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction>
 /// [LCH14]: <https://arxiv.org/abs/1404.3458>
-#[derive(Debug, Clone, Getters, CopyGetters)]
+#[derive(Debug, Clone, CopyGetters)]
 pub struct ReedSolomonCode<F> {
-	#[get = "pub"]
-	subspace: BinarySubspace<F>,
 	log_dimension: usize,
 	#[get_copy = "pub"]
 	log_inv_rate: usize,
+	_marker: PhantomData<F>,
 }
 
 impl<F: BinaryField> ReedSolomonCode<F> {
-	pub fn new(log_dimension: usize, log_inv_rate: usize) -> Self {
-		let subspace = BinarySubspace::with_dim(log_dimension + log_inv_rate);
-		Self::with_subspace(subspace, log_dimension, log_inv_rate)
-	}
-
-	pub fn with_ntt_subspace(
-		ntt: &impl AdditiveNTT<Field = F>,
-		log_dimension: usize,
-		log_inv_rate: usize,
-	) -> Self {
-		Self::with_domain_context_subspace(ntt.domain_context(), log_dimension, log_inv_rate)
-	}
-
-	pub fn with_domain_context_subspace(
-		domain_context: &impl DomainContext<Field = F>,
-		log_dimension: usize,
-		log_inv_rate: usize,
-	) -> Self {
-		let subspace_dim = log_dimension + log_inv_rate;
-		assert!(
-			subspace_dim <= domain_context.log_domain_size(),
-			"precondition: subspace dimension must not exceed domain context log size"
-		);
-		let subspace = domain_context.subspace(subspace_dim);
-		Self::with_subspace(subspace, log_dimension, log_inv_rate)
-	}
-
-	pub fn with_subspace(
-		subspace: BinarySubspace<F>,
-		log_dimension: usize,
-		log_inv_rate: usize,
-	) -> Self {
-		assert_eq!(
-			subspace.dim(),
-			log_dimension + log_inv_rate,
-			"precondition: subspace dimension must equal log_dimension + log_inv_rate"
-		);
+	/// A code of the given dimension and rate, evaluated over the Gao-Mateer basis.
+	///
+	/// The evaluation domain is not a parameter: it is the Gao-Mateer basis of `log_dimension +
+	/// log_inv_rate`, the same one [`GaoMateerOnTheFly`] and [`GaoMateerPreExpanded`] generate. A
+	/// verifier can therefore rebuild the domain from the code's shape alone, without being told
+	/// which basis the prover encoded over.
+	///
+	/// [`GaoMateerOnTheFly`]: crate::ntt::domain_context::GaoMateerOnTheFly
+	/// [`GaoMateerPreExpanded`]: crate::ntt::domain_context::GaoMateerPreExpanded
+	pub const fn new(log_dimension: usize, log_inv_rate: usize) -> Self {
 		Self {
-			subspace,
 			log_dimension,
 			log_inv_rate,
+			_marker: PhantomData,
 		}
+	}
+
+	/// The evaluation domain: the Gao-Mateer basis of [`Self::log_len`] dimensions.
+	///
+	/// Derived on demand rather than stored, so there is no way for it to disagree with the
+	/// domain a prover or verifier generates from the same dimension.
+	pub fn subspace(&self) -> BinarySubspace<F> {
+		GaoMateerOnTheFly::<F>::generate(self.log_len()).subspace(self.log_len())
 	}
 
 	/// The dimension.
@@ -136,7 +116,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 	{
 		assert_eq!(
 			ntt.subspace(self.log_len()),
-			self.subspace,
+			self.subspace(),
 			"precondition: NTT subspace must match code subspace"
 		);
 		assert_eq!(
@@ -270,7 +250,7 @@ mod tests {
 	use crate::{
 		FieldBuffer,
 		bit_reverse::reverse_bits,
-		ntt::{NeighborsLastReference, domain_context::GenericPreExpanded},
+		ntt::{NeighborsLastReference, domain_context::GaoMateerPreExpanded},
 		test_utils::random_field_buffer,
 	};
 
@@ -285,9 +265,8 @@ mod tests {
 
 		let rs_code = ReedSolomonCode::<P::Scalar>::new(log_dim, log_inv_rate);
 
-		// Create NTT with matching subspace
-		let subspace = rs_code.subspace().clone();
-		let domain_context = GenericPreExpanded::<P::Scalar>::generate_from_subspace(&subspace);
+		// The code's domain is the Gao-Mateer basis of its length, so the NTT generates the same.
+		let domain_context = GaoMateerPreExpanded::<P::Scalar>::generate(rs_code.log_len());
 		let ntt = NeighborsLastReference {
 			domain_context: &domain_context,
 		};
@@ -356,24 +335,17 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 
-		// Both codes are derived from a single shared domain context covering the larger code, so
-		// the smaller code's subspace is the prefix the shared NTT twiddles expect.
-		let subspace = BinarySubspace::<P::Scalar>::with_dim(log_dim_large + log_inv_rate);
-		let domain_context = GenericPreExpanded::<P::Scalar>::generate_from_subspace(&subspace);
+		// One shared NTT covers the larger code. Both codes evaluate over the Gao-Mateer basis, and
+		// the smaller one's is a prefix of the larger one's, which is what the shared twiddles
+		// expect -- a property the codes now have by construction rather than by wiring.
+		let domain_context =
+			GaoMateerPreExpanded::<P::Scalar>::generate(log_dim_large + log_inv_rate);
 		let ntt = NeighborsLastReference {
 			domain_context: &domain_context,
 		};
 
-		let rs_small = ReedSolomonCode::with_domain_context_subspace(
-			&domain_context,
-			log_dim_small,
-			log_inv_rate,
-		);
-		let rs_large = ReedSolomonCode::with_domain_context_subspace(
-			&domain_context,
-			log_dim_large,
-			log_inv_rate,
-		);
+		let rs_small = ReedSolomonCode::new(log_dim_small, log_inv_rate);
+		let rs_large = ReedSolomonCode::new(log_dim_large, log_inv_rate);
 
 		// Random message for the small code.
 		let msg_small = random_field_buffer::<P>(&mut rng, log_dim_small);

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -18,7 +18,7 @@ use binius_ip_prover::{
 use binius_math::{
 	FieldBuffer,
 	multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
-	ntt::{NeighborsLastSingleThread, domain_context::GenericPreExpanded},
+	ntt::{NeighborsLastSingleThread, domain_context::GaoMateerPreExpanded},
 	test_utils::random_scalars,
 };
 use binius_prover::protocols::intmul::{
@@ -52,8 +52,8 @@ const N_TEST_QUERIES: usize = 1;
 /// encoding and Merkle tree construction) is measured; a naive channel would serialize
 /// oracles for free. The final batched opening in `finish` is not measured, since the full
 /// system amortizes it into the single opening shared with the witness trace.
-fn basefold_compiler() -> BaseFoldProverCompiler<P, NeighborsLastSingleThread<GenericPreExpanded<F>>>
-{
+fn basefold_compiler()
+-> BaseFoldProverCompiler<P, NeighborsLastSingleThread<GaoMateerPreExpanded<F>>> {
 	let verifier_compiler = BaseFoldVerifierCompiler::new(
 		&BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
 		vec![OracleSpec::new(LIMB_BITS)],
@@ -61,8 +61,7 @@ fn basefold_compiler() -> BaseFoldProverCompiler<P, NeighborsLastSingleThread<Ge
 		N_TEST_QUERIES,
 		&MinProofSizeStrategy,
 	);
-	let domain_context =
-		GenericPreExpanded::generate_from_subspace(verifier_compiler.max_subspace());
+	let domain_context = GaoMateerPreExpanded::generate(verifier_compiler.max_log_domain_size());
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 	BaseFoldProverCompiler::from_verifier_compiler(&verifier_compiler, ntt)
 }

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -402,7 +402,7 @@ where
 		// Rebuild the verifier's evaluation domain, which its compiler fixed as the Gao-Mateer
 		// basis of that dimension.
 		let domain_context =
-			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_subspace().dim());
+			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_log_domain_size());
 		// FIXME TODO For mobile phones, the number of shares should potentially be more than the
 		// number of threads, because the threads/cores have different performance (but in the NTT
 		// each share has the same amount of work)

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -97,7 +97,7 @@ where
 		let outer_iop_prover = binius_spartan_prover::IOPProver::new(outer_cs);
 
 		// Build the BaseFold prover compiler from the verifier compiler.
-		let log_domain_size = zk_verifier.basefold_compiler().max_subspace().dim();
+		let log_domain_size = zk_verifier.basefold_compiler().max_log_domain_size();
 		let domain_context = {
 			let _guard = tracing::debug_span!("Precompute NTT domain").entered();
 			GaoMateerPreExpanded::generate(log_domain_size)

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -344,7 +344,7 @@ where
 		// Rebuild the verifier's evaluation domain, which its compiler fixed as the Gao-Mateer
 		// basis of that dimension.
 		let domain_context =
-			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_subspace().dim());
+			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_log_domain_size());
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
 
 		// Create the BaseFold ZK compiler from verifier compiler (reuses oracle_specs and

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -14,7 +14,7 @@ use binius_iop::{
 use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
 use binius_ip::channel::IPVerifierChannel;
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};
+use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GaoMateerOnTheFly};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, ConstraintBuilder, WitnessGenerator},
 	circuits::powers,
@@ -114,8 +114,7 @@ fn test_zk_wrapped_prove_verify() {
 		&MinProofSizeStrategy,
 	);
 
-	let subspace = zk_basefold_compiler.max_subspace();
-	let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
+	let domain_context = GaoMateerOnTheFly::generate(zk_basefold_compiler.max_log_domain_size());
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 	let zk_basefold_prover: BaseFoldProverCompiler<OptimalPackedB128, _> =
 		BaseFoldProverCompiler::from_verifier_compiler(&zk_basefold_compiler, ntt);


### PR DESCRIPTION
Closes [BINIUS-461](https://linear.app/jimpo/issue/BINIUS-461/fix-the-fri-domain-to-the-gao-mateer-basis-in-reedsolomoncode). Follows #2094 — this is the verifier side you asked for.

#2094 left `FRIVerifier` deriving its context from `params.rs_code().subspace()`, because a `ReedSolomonCode` could be built over *any* subspace. I took "fix the verifier for the Gao-Mateer basis" to mean removing that freedom rather than asserting it away, so the assumption becomes unrepresentable rather than merely checked.

**Net −152 lines.**

### `ReedSolomonCode` stops carrying a subspace

Its evaluation domain is the Gao-Mateer basis of `log_dimension + log_inv_rate`, full stop. `new` is the only constructor; `with_subspace`, `with_domain_context_subspace` and `with_ntt_subspace` are deleted. `subspace()` survives as a derived accessor, so `encode_batch` still checks the NTT agrees with the code's domain — but there is no longer a stored value for it to disagree with.

### Everything downstream falls out

- `FRIParams::optimal_for_batch` and `with_strategy` took a `domain_context` solely to build the code. That parameter is gone, along with the `DC: DomainContext` bound.
- `BaseFoldVerifierCompiler::new` therefore stops constructing a throwaway `GaoMateerOnTheFly` just to pass it, and no longer computes `max_log_code_len` at all.
- `max_subspace()` becomes `max_log_domain_size()`. Every caller only ever wanted the dimension.
- `FRIVerifier` builds `GaoMateerOnTheFly::generate(params.rs_code().log_len())`.

### What I deleted from #2094

`max_subspace_is_the_gao_mateer_basis_of_its_dimension` existed to pin the invariant that regenerating the basis from a dimension reproduces the compiler's subspace. That invariant is now structural — there is no other basis a `ReedSolomonCode` can have — so the test asserted a tautology and is gone.

The `Clone` derive on `GaoMateerOnTheFly` comes back, since `FRIVerifier` clones its context as it did with `GenericOnTheFly`.

### Test churn worth a look

Several FRI tests built their NTT over `BinarySubspace::with_dim(...)` — the default basis — and a code over a matching subspace. Those now build Gao-Mateer contexts instead. **Three of them failed first and were caught by `encode_batch`'s existing NTT-vs-code assert**, which is the check working as intended: the code's domain moved and the test's NTT hadn't.

The lift test (`test_lift_duplicate_identity_helper`) is the nicest cleanup: it used to wire both codes to a shared domain context so the smaller code's subspace would be the prefix the shared twiddles expect. Both codes are now Gao-Mateer by construction and the smaller one's basis is a prefix of the larger's automatically, so the wiring is just two `ReedSolomonCode::new` calls.

Four `let ntt = ...` locals in `crates/iop/src/fri/common.rs`'s tests existed only to supply a domain context to the constructors, and are now dead.

### Proofs

Unchanged relative to #2094 — the domain is the same Gao-Mateer basis, only the plumbing that carried it differs. `cargo test --all` green, including every prover/verifier round trip.

## Verification

`cargo test --all` green, `cargo clippy --all --tests --benches --examples -- -D warnings` clean, `cargo +nightly-2026-07-01 fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)