### PR TITLE
Turn the Merkle tree builders into constructors on the tree

### DIFF
--- a/crates/hash/benches/sha256.rs
+++ b/crates/hash/benches/sha256.rs
@@ -66,8 +66,8 @@ fn bench_compress(c: &mut Criterion) {
 
 /// Benchmarks [`ParallelDigestAdapter`] over 1 MiB of `B128` elements, varying the number of
 /// elements folded into each leaf digest (`batch_size`). This isolates the leaf-hashing step that
-/// dominates `binary_merkle_tree::build`. The input data size is fixed at 1 MiB, so a larger batch
-/// size means fewer, larger leaves (fewer SHA-256 init/finalize calls).
+/// dominates binary Merkle tree construction. The input data size is fixed at 1 MiB, so a larger
+/// batch size means fewer, larger leaves (fewer SHA-256 init/finalize calls).
 fn bench_digest(c: &mut Criterion) {
 	let mut rng = rng();
 	let elements: Vec<B128> = (0..N_ELEMS).map(|_| B128::random(&mut rng)).collect();

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -1,14 +1,16 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{fmt::Debug, mem::MaybeUninit};
-
 use binius_field::Field;
 use binius_utils::{
 	checked_arithmetics::checked_log_2,
 	rayon::{prelude::*, slice::ParallelSlice},
 };
-use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
+use digest::{
+	Digest, FixedOutputReset, Output, OutputSizeUser,
+	array::{Array, ArraySize},
+	block_api::BlockSizeUser,
+};
 
 use super::{
 	compress::CompressionFunction, parallel_compression::ParallelPseudoCompression,
@@ -62,123 +64,123 @@ pub struct BinaryMerkleTree<D> {
 	pub inner_nodes: Vec<D>,
 }
 
-/// Commits a slice of values, cutting it into consecutive leaves.
-///
-/// # Arguments
-///
-/// * `elements` - the values to commit, in leaf order.
-/// * `batch_size` - how many consecutive values are hashed together into one leaf.
-///
-/// # Returns
-///
-/// The committed tree, or a failure describing which shape requirement the input broke.
-///
-/// # Errors
-///
-/// * The value count is not a multiple of the batch size.
-/// * The resulting leaf count is not a power of two.
-pub fn build<F, H>(
-	elements: &[F],
-	batch_size: usize,
-) -> Result<BinaryMerkleTree<Output<H::LeafHash>>, Error>
-where
-	F: Field,
-	H: HashSuite,
-{
-	// Every leaf holds the same number of values, so the split has to come out even.
-	if !elements.len().is_multiple_of(batch_size) {
-		return Err(Error::IncorrectBatchSize);
+impl<N: ArraySize> BinaryMerkleTree<Array<u8, N>> {
+	/// Commits a slice of values, cutting it into consecutive leaves.
+	///
+	/// # Arguments
+	///
+	/// * `elements` - the values to commit, in leaf order.
+	/// * `batch_size` - how many consecutive values are hashed together into one leaf.
+	///
+	/// # Errors
+	///
+	/// * The value count is not a multiple of the batch size.
+	/// * The resulting leaf count is not a power of two.
+	pub fn new<F, H>(elements: &[F], batch_size: usize) -> Result<Self, Error>
+	where
+		F: Field,
+		H: HashSuite<LeafHash: OutputSizeUser<OutputSize = N>>,
+	{
+		// Every leaf holds the same number of values, so the split has to come out even.
+		if !elements.len().is_multiple_of(batch_size) {
+			return Err(Error::IncorrectBatchSize);
+		}
+
+		// A binary tree only spans a power-of-two number of leaves.
+		let len = elements.len() / batch_size;
+		if !len.is_power_of_two() {
+			return Err(Error::PowerOfTwoLengthRequired);
+		}
+
+		// Hand the leaves over one contiguous chunk at a time.
+		Ok(Self::from_leaves::<F, H, _>(
+			elements
+				.par_chunks(batch_size)
+				.map(|chunk| chunk.iter().copied()),
+			batch_size,
+		))
 	}
 
-	// A binary tree only spans a power-of-two number of leaves.
-	let len = elements.len() / batch_size;
-	if !len.is_power_of_two() {
-		return Err(Error::PowerOfTwoLengthRequired);
-	}
+	/// Commits leaves drawn from a parallel iterator, one iterator item per leaf.
+	///
+	/// # Overview
+	///
+	/// The tree is laid out as one flat buffer of layers, widest first:
+	///
+	/// ```text
+	///     [ leaf digests | layer 1 | ... | root ]
+	///        2^log_len      2^(log_len-1)    1
+	/// ```
+	///
+	/// Each layer is written into the buffer's spare capacity.
+	/// It is then read back as the input to the layer above it.
+	///
+	/// # Arguments
+	///
+	/// * `leaves` - one iterator per leaf, each yielding that leaf's values.
+	/// * `n_items_per_input` - how many values every leaf iterator yields.
+	///
+	/// # Panics
+	///
+	/// Panics unless the number of leaves is a power of two.
+	pub fn from_leaves<F, H, ParIter>(leaves: ParIter, n_items_per_input: usize) -> Self
+	where
+		F: Field,
+		H: HashSuite<LeafHash: OutputSizeUser<OutputSize = N>>,
+		ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
+	{
+		// Panics unless the leaf count is a power of two, which the binary layout requires.
+		let log_len = checked_log_2(leaves.len());
 
-	// Hand the leaves over one contiguous chunk at a time.
-	build_from_iterator::<_, H, _>(
-		elements
-			.par_chunks(batch_size)
-			.map(|chunk| chunk.iter().copied()),
-		batch_size,
-	)
-}
+		// A binary tree over 2^log_len leaves has 2^(log_len+1) - 1 nodes in total.
+		let total_length = (1 << (log_len + 1)) - 1;
+		let mut inner_nodes = Vec::with_capacity(total_length);
 
-/// Commits leaves drawn from a parallel iterator, one iterator item per leaf.
-///
-/// # Overview
-///
-/// The tree is laid out as one flat buffer of layers, widest first:
-///
-/// ```text
-///     [ leaf digests | layer 1 | ... | root ]
-///        2^log_len      2^(log_len-1)    1
-/// ```
-///
-/// Each layer is written into the buffer's spare capacity.
-/// It is then read back as the input to the layer above it.
-///
-/// # Arguments
-///
-/// * `iterated_chunks` - one iterator per leaf, each yielding that leaf's values.
-/// * `n_items_per_input` - how many values every leaf iterator yields.
-///
-/// # Panics
-///
-/// Panics unless the number of leaves is a power of two.
-pub fn build_from_iterator<F, H, ParIter>(
-	iterated_chunks: ParIter,
-	n_items_per_input: usize,
-) -> Result<BinaryMerkleTree<Output<H::LeafHash>>, Error>
-where
-	F: Field,
-	H: HashSuite,
-	ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
-{
-	let log_len = checked_log_2(iterated_chunks.len()); // precondition
+		// Fill the widest layer first, straight into uninitialized capacity.
+		{
+			let _span = tracing::debug_span!("hash_leaves").entered();
 
-	// A binary tree over 2^log_len leaves has 2^(log_len+1) - 1 nodes in total.
-	let total_length = (1 << (log_len + 1)) - 1;
-	let mut inner_nodes = Vec::with_capacity(total_length);
+			// Every leaf holds exactly the same number of values, so its byte length is a constant.
+			// Handing that length to the hasher lets it specialize for short leaves.
+			H::ParLeafHash::default().digest_with_const_len(
+				n_items_per_input,
+				leaves,
+				&mut inner_nodes.spare_capacity_mut()[..(1 << log_len)],
+			);
+		}
 
-	// Fill the widest layer first, straight into uninitialized capacity.
-	hash_leaves::<F, H, _>(
-		iterated_chunks,
-		n_items_per_input,
-		&mut inner_nodes.spare_capacity_mut()[..(1 << log_len)],
-	);
+		let (prev_layer, mut remaining) =
+			inner_nodes.spare_capacity_mut().split_at_mut(1 << log_len);
 
-	let (prev_layer, mut remaining) = inner_nodes.spare_capacity_mut().split_at_mut(1 << log_len);
-
-	let mut prev_layer = unsafe {
-		// SAFETY: prev-layer was initialized by hash_leaves
-		prev_layer.assume_init_mut()
-	};
-	// Fold one layer per round, each half the width of the one below it.
-	let parallel_compression = H::ParCompression::default();
-	for i in 1..(log_len + 1) {
-		let (next_layer, next_remaining) = remaining.split_at_mut(1 << (log_len - i));
-		remaining = next_remaining;
-
-		parallel_compression.parallel_compress(prev_layer, next_layer);
-
-		prev_layer = unsafe {
-			// SAFETY: next_layer was just initialized by compress_layer
-			next_layer.assume_init_mut()
+		let mut prev_layer = unsafe {
+			// SAFETY: the leaf digests were just written over the whole widest layer
+			prev_layer.assume_init_mut()
 		};
-	}
+		// Fold one layer per round, each half the width of the one below it.
+		let parallel_compression = H::ParCompression::default();
+		for i in 1..(log_len + 1) {
+			let (next_layer, next_remaining) = remaining.split_at_mut(1 << (log_len - i));
+			remaining = next_remaining;
 
-	unsafe {
-		// SAFETY: inner_nodes should be entirely initialized by now
-		// Note that we don't incrementally update inner_nodes.len() since
-		// that doesn't play well with using split_at_mut on spare capacity.
-		inner_nodes.set_len(total_length);
+			parallel_compression.parallel_compress(prev_layer, next_layer);
+
+			prev_layer = unsafe {
+				// SAFETY: the compression above wrote every slot of the next layer
+				next_layer.assume_init_mut()
+			};
+		}
+
+		unsafe {
+			// SAFETY: inner_nodes should be entirely initialized by now
+			// Note that we don't incrementally update inner_nodes.len() since
+			// that doesn't play well with using split_at_mut on spare capacity.
+			inner_nodes.set_len(total_length);
+		}
+		Self {
+			log_len,
+			inner_nodes,
+		}
 	}
-	Ok(BinaryMerkleTree {
-		log_len,
-		inner_nodes,
-	})
 }
 
 impl<D: Clone> BinaryMerkleTree<D> {
@@ -217,29 +219,4 @@ impl<D: Clone> BinaryMerkleTree<D> {
 
 		Ok(branch)
 	}
-}
-
-/// Hashes the elements in chunks of a vector into digests.
-///
-/// Given a vector of elements and an output buffer of N hash digests, this splits the elements
-/// into N equal-sized chunks and hashes each chunks into the corresponding output digest.
-///
-/// Every leaf holds exactly `n_items_per_input` values, so its byte length is a constant.
-/// Passing that length to the hasher lets it specialize for short leaves.
-///
-/// # Preconditions
-/// - Each iterator in `iterated_chunks` yields exactly `n_items_per_input` elements.
-#[tracing::instrument("hash_leaves", skip_all, level = "debug")]
-fn hash_leaves<F, H, ParIter>(
-	iterated_chunks: ParIter,
-	n_items_per_input: usize,
-	digests: &mut [MaybeUninit<Output<H::LeafHash>>],
-) where
-	F: Field,
-	H: HashSuite,
-	ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
-{
-	// The constant leaf length lets the hasher skip per-leaf length bookkeeping and padding.
-	let hasher = H::ParLeafHash::default();
-	hasher.digest_with_const_len(n_items_per_input, iterated_chunks, digests);
 }

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::Field;
-use binius_hash::binary_merkle_tree::{self, BinaryMerkleTree, HashSuite};
+use binius_hash::binary_merkle_tree::{BinaryMerkleTree, HashSuite};
 use binius_iop::merkle_tree::{BinaryMerkleTreeScheme, Commitment};
 use binius_transcript::{BufMut, TranscriptWriter};
 use binius_utils::rayon::iter::IndexedParallelIterator;
@@ -70,8 +70,7 @@ where
 	where
 		ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 	{
-		let tree = binary_merkle_tree::build_from_iterator::<F, H, _>(leaves, n_items_per_input)
-			.expect("precondition: the number of leaves must be a power of two");
+		let tree = BinaryMerkleTree::from_leaves::<F, H, _>(leaves, n_items_per_input);
 
 		let commitment = Commitment {
 			root: tree.root(),


### PR DESCRIPTION
Moves the two free functions that build a binary Merkle tree onto the type they produce, and drops a `Result` that could never be `Err`.
Pure refactor — no behavior change, no protocol change.

### The problem

Building a tree read as two loose free functions plus a private helper, all generic over the same hash suite:

```
binary_merkle_tree::build::<F, H>(elements, batch_size)          -> Result<BinaryMerkleTree<..>, Error>
binary_merkle_tree::build_from_iterator::<F, H, _>(leaves, n)    -> Result<BinaryMerkleTree<..>, Error>
binary_merkle_tree::hash_leaves::<F, H, _>(..)                   // private, single caller
```

Two problems come out of that shape.

- The constructors are not discoverable from the type: nothing on `BinaryMerkleTree` tells you how to make one.
- The iterator builder returns a `Result` it never fills. A non-power-of-two leaf count panics inside the log-2 check, so the error path is unreachable and its only caller has to `.expect` a value that can never arrive.

The helper is a third layer for six lines that are used exactly once.

### The idea

Put both constructors in an `impl` block on the tree, inline the helper, and let the panicking constructor say so in its signature.

The subtle part is which generic goes where.
The obvious spelling puts the hash suite on the impl:

```
impl<H: HashSuite> BinaryMerkleTree<Output<H::LeafHash>>   // does not work
```

That does not compile at any call site.
`Output<H::LeafHash>` is an associated-type projection, and projections are not injective, so the compiler cannot recover `H` from the self type — and an impl generic cannot be turbofished to supply it by hand.

The fix is to keep the suite as a *function* generic and write the digest in its structural form:

```
impl<N: ArraySize> BinaryMerkleTree<Array<u8, N>> {
    pub fn new<F, H>(..)         -> Result<Self, Error>
    pub fn from_leaves<F, H, _>(..) -> Self
    where H: HashSuite<LeafHash: OutputSizeUser<OutputSize = N>>
}
```

Now the caller names `H` explicitly, and `N` follows from it through the where-clause equality.

### The change

At the one in-tree call site, in `crates/iop-prover/src/merkle_tree/prover.rs`:

```diff
-let tree = binary_merkle_tree::build_from_iterator::<F, H, _>(leaves, n_items_per_input)
-    .expect("precondition: the number of leaves must be a power of two");
+let tree = BinaryMerkleTree::from_leaves::<F, H, _>(leaves, n_items_per_input);
```

`new` keeps its `Result`, because its two errors are real: a value count that is not a multiple of the batch size, and a leaf count that is not a power of two.

### Scope

- **changed:** `crates/hash/src/binary_merkle_tree.rs` — two free functions become constructors, the leaf-hashing helper is inlined.
- **changed:** `crates/iop-prover/src/merkle_tree/prover.rs` — the single call site, minus its `.expect`.
- **kept:** the leaf-hashing `tracing` span is preserved by name, so existing profiles are unchanged.
- **untouched:** the tree layout, the hashing and compression traits, and the accessors for the root, a layer, and a branch.
- **note:** `new` has no in-tree caller, and neither did the free `build` it replaces — it stays as public API.

### Documentation

Three comments were stale and are fixed along the way.

- A safety comment named the helper that no longer exists.
- Another named a `compress_layer` function that never existed in this file.
- A trailing `// precondition` on the log-2 call now states what panics and why.

### Verification

- `cargo check --workspace --all-targets` — clean, no warnings.
- `cargo clippy -p binius-hash -p binius-iop-prover --all-targets` — clean.
- `cargo +nightly fmt --all` — applied.
- `cargo test -p binius-hash` — 21 passed.
- `cargo test --workspace merkle` — 10 passed.

One unrelated build failure exists on `main` and is not touched by this PR: `cargo test -p binius-iop-prover --features rayon` fails to compile `binius-ip-prover`, which needs a `Sync` bound on a sumcheck buffer type. Reproduced with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)